### PR TITLE
Program Search Changes from CEPS 

### DIFF
--- a/data/yaml/programs/graduate.yml
+++ b/data/yaml/programs/graduate.yml
@@ -272,7 +272,7 @@
     - engineering
     - artificial intelligence
     - ai
-- name: Engineering (MEng)
+- name: Engineering
   url: https://www.uoguelph.ca/programs/master-of-engineering
   degrees:
     - MEng

--- a/data/yaml/programs/graduate.yml
+++ b/data/yaml/programs/graduate.yml
@@ -263,9 +263,19 @@
 - name: Engineering
   url: https://graduatestudies.uoguelph.ca/programs/engg
   degrees:
-    - MEng
     - MASc
     - PhD
+  types:
+    - thesis-based
+  tags:
+    - technology
+    - engineering
+    - artificial intelligence
+    - ai
+- name: Engineering (MEng)
+  url: https://www.uoguelph.ca/programs/master-of-engineering
+  degrees:
+    - MEng
   types:
     - course-based
   tags:


### PR DESCRIPTION
One small change to the program search from CEPS. Esentially they wanted Engineering in the graduate tab to be split into two cards: One for MEng and one for PhD and MASc.

Screenshot of what they wanted:
![3bc4ceb6-6092-4545-a797-e1235bd24897](https://github.com/user-attachments/assets/e4d24d9d-1325-4a53-8c18-33f36edf5448)

Test Plan:
1. Go to https://deploy-preview-34--ugnext.netlify.app/programs/graduate
3. Type "Engineering" into the search bar
4. Ensure two cards show up that look like the screenshot above. (Note the order they appear in doesn't matter).