### PR TITLE
Update graduate programs in program search

### DIFF
--- a/data/yaml/programs/graduate.yml
+++ b/data/yaml/programs/graduate.yml
@@ -89,7 +89,6 @@
     - MBS
     - MSc
     - PhD
-    - DVSc
   types:
     - course-based
   tags:

--- a/data/yaml/programs/graduate.yml
+++ b/data/yaml/programs/graduate.yml
@@ -34,25 +34,6 @@
   tags:
     - health
     - food
-- name: Art History and Visual Culture
-  url: https://graduatestudies.uoguelph.ca/programs/avc
-  degrees:
-    - MA
-  types:
-    - thesis-based
-    - course-based
-  tags:
-    - arts
-    - culture
-    - history
-    - art market
-    - art*
-    - changemaking
-    - cultur*
-    - fine art
-    - fundraising
-    - human perceptions behaviour
-    - identit*
 - name: Artificial Intelligence
   url: https://graduatestudies.uoguelph.ca/programs/csai
   degrees:
@@ -377,7 +358,7 @@
     - cultur*
     - poetry
     - teach*
-- name: Criminology and Criminal Justice Policy
+- name: Criminal Justice and Public Policy
   url: https://graduatestudies.uoguelph.ca/programs/ccjp
   degrees:
     - MA
@@ -399,7 +380,6 @@
 - name: Critical Studies in Improvisation
   url: https://graduatestudies.uoguelph.ca/programs/impr
   degrees:
-    - MA
     - PhD
   types:
     - course-based
@@ -417,6 +397,31 @@
   url: https://graduatestudies.uoguelph.ca/programs/mcti
   degrees:
     - MCTI
+  types:
+    - course-based
+  tags:
+    - technology
+    - science
+    - mathematics
+    - programming
+    - attacks and defenses
+    - biology
+    - crime
+    - cryptography
+    - cybersecurity
+    - data*
+    - digital forensics
+    - government*
+    - information technology
+    - organization*
+    - privacy
+    - security
+    - security architecture
+    - threat
+- name: Cybersecurity Leadership and Cyberpreneurship
+  url: https://graduatestudies.uoguelph.ca/programs/mclc
+  degrees:
+    - MCLC
   types:
     - course-based
   tags:
@@ -511,6 +516,35 @@
   url: https://www.uoguelph.ca/programs/master-of-engineering
   degrees:
     - MEng
+  types:
+    - course-based
+  tags:
+    - technology
+    - engineering
+    - artificial intelligence
+    - ai
+    - agriculture engineering
+    - energy
+    - food engineering
+    - food*
+    - government policy
+    - innovation
+    - intelligent systems
+    - law*
+    - machine learning
+    - physical design
+    - research development
+    - resource management
+    - software engineering
+    - software development
+    - sustainab*
+    - sustainable energy systems
+    - waste management
+    - water*
+- name: Engineering Management
+  url: https://graduatestudies.uoguelph.ca/programs/engineering-management
+  degrees:
+    - MEM
   types:
     - course-based
   tags:
@@ -915,16 +949,6 @@
     - socio-cultural design
     - sustainab*
     - tourism*
-- name: Latin American and Caribbean Studies
-  url: https://graduatestudies.uoguelph.ca/programs/lacs
-  degrees:
-    - MA
-  types:
-    - course-based
-  tags:
-    - humanities
-    - culture
-    - history
 - name: Leadership
   url: https://graduatestudies.uoguelph.ca/programs/lead
   degrees:
@@ -1413,6 +1437,16 @@
     - sustainab*
     - water*
     - waterbourne diseases
+- name: Professional Accounting
+  url: https://graduatestudies.uoguelph.ca/programs/accounting
+  degrees:
+    - MPAcc
+  types:
+    - course-based
+  tags:
+    - business
+    - management
+    - finance
 - name: Project Management
   url: https://graduatestudies.uoguelph.ca/programs/project-management
   degrees:
@@ -1574,7 +1608,7 @@
     - social justice
     - water*
 - name: Real Estate
-  url: https://www.uoguelph.ca/lang/masters-real-estate/
+  url: https://graduatestudies.uoguelph.ca/programs/master-of-real-estate
   degrees:
     - MRE
   types:


### PR DESCRIPTION
List of changes:

- Remove Latin American and Caribbean Studies
- Remove Art History and Visual Culture
- Remove the degree MA from Critical Studies in Improvisation
- Remove DVSc from Biomedical Sciences
- Change the name of CCJP to “Criminal Justice and Public Policy” (formerly Criminology and Criminal Justice Policy)
- Change the link on Real Estate (MRE)
- Add the program Engineering Management
- Add the program Professional Accounting
- Add the program Cybersecurity Leadership and Cyberpreneurship
