### PR TITLE
Allow caption prop in LinkCarousel to accept strings or nodes

### DIFF
--- a/components/link-carousel.js
+++ b/components/link-carousel.js
@@ -85,7 +85,7 @@ LinkCarousel.propTypes = {
         className: PropTypes.string,
         blurred: PropTypes.string,
       }).isRequired,
-      caption: PropTypes.string,
+      caption: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     })
   ).isRequired,
 };


### PR DESCRIPTION
# Summary of changes

This update changes the `caption` prop type to accept both strings and React nodes. It enhances flexibility by supporting richer content for captions in the LinkCarousel component.

For example, previously this would cause an error:

```
<LinkCarousel links={[{
    image: {
      src: graduate.src,
      width: graduate.width,
      height: graduate.height,
      blurred: graduate.blurDataURL,
      alt: "Caroline Pottruff working in a forest with a hard hat on",
    },
    title: "Graduate Programs",
    url: "https://graduatestudies.uoguelph.ca/",
    caption: <a href="#" className="text-2xl text-red">Caroline Pottruff - Landscape Architecture</a>,
  },]} />
```

as caption was only allowed to be a string.

## Frontend
Modified prop-types in components/link-carousel.js

[x] My changes are accessible (at minimum WCAG 2.0 Level AA)
[x] My changes are responsive and appear as expected on mobile and desktop views.
[x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan
1. The preview should be exactly the same as it was before.