### PR TITLE
Fix spotlight thumbnailImageCrop variable

### DIFF
--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -17,9 +17,9 @@ export const SpotlightCards = ({ cards }) => (
           height: card.image.image.height,
           className: twJoin(
             "aspect-[3/2] w-full",
-            card.thumbnailImageCropping === "right" && "object-right",
-            card.thumbnailImageCropping === "left" && "object-left",
-            card.thumbnailImageCropping === "center" && "object-center"
+            card.thumbnailImageCrop === "right" && "object-right",
+            card.thumbnailImageCrop === "left" && "object-left",
+            card.thumbnailImageCrop === "center" && "object-center"
           ),
           sizes: "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw",
         }}

--- a/components/home/spotlight-hero.js
+++ b/components/home/spotlight-hero.js
@@ -12,9 +12,9 @@ export const SpotlightHero = ({ hero }) => (
       height: hero.image.image.height,
       className: twJoin(
         "aspect-[3/2] w-full",
-        hero.thumbnailImageCropping === "right" && "object-right",
-        hero.thumbnailImageCropping === "left" && "object-left",
-        (hero.thumbnailImageCropping === "center" || !hero.thumbnailImageCropping) && "object-center"
+        hero.thumbnailImageCrop === "right" && "object-right",
+        hero.thumbnailImageCrop === "left" && "object-left",
+        (hero.thumbnailImageCrop === "center" || !hero.thumbnailImageCrop) && "object-center"
       ),
     }}
     caption={hero.caption}


### PR DESCRIPTION
# Summary of changes
Fixed Spotlight hero and cards so they pull in the correct variable (thumbnailImageCrop instead of thumbnailImageCropping)

## Frontend
- Fixed Spotlight hero and cards so they pull in the correct variable (thumbnailImageCrop instead of thumbnailImageCropping)

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Open the homepage on the PR deployment: https://deploy-preview-50--ugnext.netlify.app/
2. Make the viewport mobile-sized
3. The image should appear properly (in this case right-aligned as it is set in the backend)

**Before**
<img width="554" alt="image" src="https://github.com/user-attachments/assets/2eef9a68-fa34-452f-890d-14349af11cd3" />

**After**
<img width="555" alt="image" src="https://github.com/user-attachments/assets/e33f80fc-b596-4a43-a395-7503af68be75" />
