### PR TITLE
Update spotlight-hero to include direct image URL in the component

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -22,7 +22,6 @@ export const Hero = ({ variant = "spotlight", image, video, title, caption, butt
         width={image?.width}
         height={image?.height}
         priority
-        sizes="100vw"
         placeholder={image?.blurred ? "blur" : "empty"}
         blurDataURL={image?.blurred}
       />

--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -11,7 +11,7 @@ export const SpotlightCards = ({ cards }) => (
         href={card.url.url}
         centered
         image={{
-          src: card.image.image.variations[0].url,
+          src: card.image.image.url,
           alt: card.image.image.alt,
           width: card.image.image.width,
           height: card.image.image.height,

--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -21,7 +21,6 @@ export const SpotlightCards = ({ cards }) => (
             card.thumbnailImageCrop === "left" && "object-left",
             card.thumbnailImageCrop === "center" && "object-center"
           ),
-          sizes: "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw",
         }}
       />
     ))}

--- a/components/home/spotlight-hero.js
+++ b/components/home/spotlight-hero.js
@@ -6,7 +6,7 @@ export const SpotlightHero = ({ hero }) => (
     variant="spotlight"
     title={<h2>{hero.title}</h2>}
     image={{
-      src: hero.image.image.variations[0].url,
+      src: hero.image.image.url,
       alt: hero.image.image.alt,
       width: hero.image.image.width,
       height: hero.image.image.height,

--- a/data/drupal/home/spotlight-card.graphql
+++ b/data/drupal/home/spotlight-card.graphql
@@ -8,9 +8,7 @@ query SpotlightCard($status: Boolean = false, $id: String = "") {
               alt
               height
               width
-              variations(styles: SPOTLIGHT_CARD_IMAGE) {
-                url
-              }
+              url
             }
           }
         }

--- a/data/drupal/home/spotlight-hero.graphql
+++ b/data/drupal/home/spotlight-hero.graphql
@@ -18,9 +18,6 @@ query SpotlightHero($status: Boolean = null) {
               alt
               width
               url
-              variations(styles: SPOTLIGHT_HERO_IMAGE) {
-                url
-              }
             }
           }
         }

--- a/data/drupal/home/spotlight-hero.graphql
+++ b/data/drupal/home/spotlight-hero.graphql
@@ -17,6 +17,7 @@ query SpotlightHero($status: Boolean = null) {
               height
               alt
               width
+              url
               variations(styles: SPOTLIGHT_HERO_IMAGE) {
                 url
               }


### PR DESCRIPTION
# Summary of changes
For some reason using an image from Drupal's image styles for the spotlight hero results in a lower resolution image than it should.

## Frontend
Update spotlight-hero.js to use direct image URL, and update spotlight-hero.graphql to pull direct image url

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

Insert steps. Include URLs of Netlify test site and Drupal multidev.