### PR TITLE
Remove hyphenation from stats

### DIFF
--- a/components/statistics.js
+++ b/components/statistics.js
@@ -83,7 +83,7 @@ export const Statistics = ({ data, variant = "gradient-of-solid-colors" }) => {
               color
             )}
           >
-            <dt className="break-auto hyphens-auto p-6 pb-0 text-center font-bold leading-tight text-3xl">{value}</dt>
+            <dt className="break-auto p-6 pb-0 text-center font-bold leading-tight text-3xl">{value}</dt>
             <dd className="text-normal p-6 pt-0 text-center font-normal text-lg">{represents}</dd>
 
             {image && (


### PR DESCRIPTION
# Summary of changes
Remove hyphenation from stats

## Frontend
- Remove hyphenation from stats

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Hyphens should not appear in the statistics: https://deploy-preview-55--ugnext.netlify.app/
2. This may only affect Safari browsers (I'm only seeing them in Safari, not Firefox or Chrome)

Before:
<img width="1530" alt="image" src="https://github.com/user-attachments/assets/8743db1b-6316-4e25-b935-ff821d2da80c" />

After:
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/e50f3e09-c45a-4522-a9fe-b8790cbb5f75" />

If you do not have access to Safari, here's my confirmation that it's working as expected in Safari:
<img width="1696" alt="image" src="https://github.com/user-attachments/assets/7b6def59-45be-4003-b34a-ae148d7bc176" />
