### PR TITLE
Homepage and Program Search updates

### DIFF
--- a/components/home/tag-line.js
+++ b/components/home/tag-line.js
@@ -3,7 +3,7 @@ import { Heading } from "@/components/heading";
 export const TagLine = () => (
   <>
     <div className="flex flex-col items-center justify-center py-4">
-      <Heading level={1}>
+      <Heading level={1} className="mt-[4rem]">
         University of Guelph, Ontario, Canada
       </Heading>
       <span className="mt-2 text-center text-2xl">Improve Life</span>

--- a/components/navigation.js
+++ b/components/navigation.js
@@ -16,7 +16,7 @@ export const Navigation = ({ fullWidth = true, links, label }) => {
             <a
               aria-current={pathname === link?.href ? "page" : undefined}
               className={twJoin(
-                "mb-1 flex items-center justify-center rounded-t-sm bg-uog-grey-light-bg px-4 py-3 text-center text-lg font-bold text-black transition-colors hover:bg-gray-300 focus:bg-gray-300 focus:outline-none aria-page-current:mb-0 aria-page-current:border-2 aria-page-current:border-uog-yellow aria-page-current:bg-uog-yellow",
+                "mb-1 flex items-center justify-center rounded-t-sm bg-uog-grey-light-bg px-4 py-3 text-center text-lg font-bold text-black transition-colors hover:bg-uog-grey-light focus:bg-uog-grey-light focus:outline-none aria-page-current:mb-0 aria-page-current:border-2 aria-page-current:border-uog-yellow aria-page-current:bg-uog-yellow",
                 fullWidth && "flex-1"
               )}
               href={link?.href}

--- a/components/programs/program-search-bar.js
+++ b/components/programs/program-search-bar.js
@@ -31,7 +31,7 @@ export const ProgramSearchBar = ({ programs, types, degreeTypes, onChange, class
   }, [filtered, onChange]);
 
   return (
-    <div className={twMerge("flex flex-col gap-4 sm:flex-row sm:items-end", className)}>
+    <div className={twMerge("bg-uog-yellow flex flex-col gap-4 p-5 sm:flex-row sm:items-end", className)}>
       <div className="flex-1">
         <TextInput
           onInput={(value) => setInput(value)}

--- a/components/programs/program-search-bar.js
+++ b/components/programs/program-search-bar.js
@@ -3,6 +3,7 @@ import { Select } from "@/components/select";
 import { useSearch, nameAndTagSearch } from "@/lib/use-search";
 import { useEffect, useMemo, useState } from "react";
 import { twMerge } from "tailwind-merge";
+import { Container } from "@/components/container";
 
 export const ProgramSearchBar = ({ programs, types, degreeTypes, onChange, className }) => {
   const [input, setInput] = useState("");
@@ -31,40 +32,45 @@ export const ProgramSearchBar = ({ programs, types, degreeTypes, onChange, class
   }, [filtered, onChange]);
 
   return (
-    <div className={twMerge("bg-uog-yellow flex flex-col gap-4 p-5 sm:flex-row sm:items-end", className)}>
-      <div className="flex-1">
-        <TextInput
-          onInput={(value) => setInput(value)}
-          label={<span className="text-xl font-bold mb-1">What would you like to study?</span>}
-          placeholder="ex. programming, engineering, psychology, etc."
-        />
-      </div>
-
-      {types?.length > 0 && (
-        <div className="sm:w-1/3 md:w-1/4">
-          <Select
-            multiple
-            options={types.map((type) => ({ label: type.name, value: type.id, selected: true }))}
-            onChange={(options) => {
-              setSelectedTypes(options.map((option) => option.value));
-            }}
-            label={<span className="text-xl font-bold">Filter by type</span>}
+    <div className="w-full bg-uog-yellow -mt-1">
+      <Container
+        centered
+        className={twMerge("bg-uog-yellow flex flex-col gap-4 p-5 sm:flex-row sm:items-end", className)}
+      >
+        <div className="flex-1">
+          <TextInput
+            onInput={(value) => setInput(value)}
+            label={<span className="text-xl font-bold mb-1">What would you like to study?</span>}
+            placeholder="ex. programming, engineering, psychology, etc."
           />
         </div>
-      )}
 
-      {degreeTypes?.length > 0 && (
-        <div className="sm:w-1/3 md:w-1/4">
-          <Select
-            multiple
-            options={degreeTypes.map((type) => ({ label: type.name, value: type.id, selected: true }))}
-            onChange={(options) => {
-              setSelectedDegreeTypes(options.map((option) => option.value));
-            }}
-            label={<span className="text-xl font-bold">Filter by degree type</span>}
-          />
-        </div>
-      )}
+        {types?.length > 0 && (
+          <div className="sm:w-1/3 md:w-1/4">
+            <Select
+              multiple
+              options={types.map((type) => ({ label: type.name, value: type.id, selected: true }))}
+              onChange={(options) => {
+                setSelectedTypes(options.map((option) => option.value));
+              }}
+              label={<span className="text-xl font-bold">Filter by type</span>}
+            />
+          </div>
+        )}
+
+        {degreeTypes?.length > 0 && (
+          <div className="sm:w-1/3 md:w-1/4">
+            <Select
+              multiple
+              options={degreeTypes.map((type) => ({ label: type.name, value: type.id, selected: true }))}
+              onChange={(options) => {
+                setSelectedDegreeTypes(options.map((option) => option.value));
+              }}
+              label={<span className="text-xl font-bold">Filter by degree type</span>}
+            />
+          </div>
+        )}
+      </Container>
     </div>
   );
 };

--- a/components/programs/program-search-navigation.js
+++ b/components/programs/program-search-navigation.js
@@ -2,7 +2,7 @@ import { Navigation } from "@/components/navigation";
 
 export const ProgramSearchNavigation = () => {
   return (
-    <div className="my-5">
+    <div className="mt-5">
       <Navigation
         label="Level of Study"
         links={[

--- a/components/programs/program-search.js
+++ b/components/programs/program-search.js
@@ -7,15 +7,16 @@ export const ProgramSearch = ({ programs, types, degreeTypes, condensedDegrees =
   const [filteredPrograms, setFilteredPrograms] = useState(programs);
 
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col relative">
+    
+      <ProgramSearchNavigation />
+
       <ProgramSearchBar
         programs={programs}
         types={types}
         degreeTypes={degreeTypes}
         onChange={(filtered) => setFilteredPrograms(filtered)}
       />
-
-      <ProgramSearchNavigation />
 
       <ProgramGrid programs={filteredPrograms} condensedDegrees={condensedDegrees} />
 

--- a/components/programs/program-search.js
+++ b/components/programs/program-search.js
@@ -2,14 +2,16 @@ import { ProgramSearchBar } from "@/components/programs/program-search-bar";
 import { ProgramSearchNavigation } from "@/components/programs/program-search-navigation";
 import { ProgramGrid } from "@/components/programs/program-grid";
 import { useState } from "react";
+import { Container } from "@/components/container";
 
 export const ProgramSearch = ({ programs, types, degreeTypes, condensedDegrees = false }) => {
   const [filteredPrograms, setFilteredPrograms] = useState(programs);
 
   return (
     <div className="flex flex-col relative">
-    
-      <ProgramSearchNavigation />
+      <Container centered className="py-0">
+        <ProgramSearchNavigation />
+      </Container>
 
       <ProgramSearchBar
         programs={programs}
@@ -18,14 +20,16 @@ export const ProgramSearch = ({ programs, types, degreeTypes, condensedDegrees =
         onChange={(filtered) => setFilteredPrograms(filtered)}
       />
 
-      <ProgramGrid programs={filteredPrograms} condensedDegrees={condensedDegrees} />
+      <Container centered>
+        <ProgramGrid programs={filteredPrograms} condensedDegrees={condensedDegrees} />
 
-      {/* No results were found */}
-      {filteredPrograms?.length === 0 && (
-        <div className="flex w-full items-center justify-center">
-          <span className="text-xl font-bold text-black/50">No programs matching your criteria were found.</span>
-        </div>
-      )}
+        {/* No results were found */}
+        {filteredPrograms?.length === 0 && (
+          <div className="flex w-full items-center justify-center">
+            <span className="text-xl font-bold text-black/50">No programs matching your criteria were found.</span>
+          </div>
+        )}
+      </Container>
     </div>
   );
 };

--- a/components/select.js
+++ b/components/select.js
@@ -107,7 +107,7 @@ export const Select = ({
             </ButtonTag>
           </div>
         ) : (
-          <ButtonTag className="flex w-full items-center justify-between rounded-md border border-gray-300 px-4 py-2 shadow-sm transition-colors group-focus-within:border-blue group-focus-within:outline-none ui-open:rounded-b-none ui-open:border-blue">
+          <ButtonTag className="bg-white flex w-full items-center justify-between rounded-md border border-gray-300 px-4 py-2 shadow-sm transition-colors group-focus-within:border-blue group-focus-within:outline-none ui-open:rounded-b-none ui-open:border-blue">
             <span className={twJoin("truncate", (!selected || selected?.length === 0) && "text-gray-400")}>
               {labelText ?? placeholderText}
             </span>

--- a/components/text-input.js
+++ b/components/text-input.js
@@ -17,7 +17,7 @@ export const TextInput = ({ value = "", type = "text", placeholder = "", onInput
     <Field className="flex flex-col gap-0.5">
       {label && <Label>{label}</Label>}
 
-      <div className="text-input flex rounded-md border border-gray-300 px-4 py-2 transition-colors focus-within:border-blue focus:outline-none">
+      <div className="bg-white text-input flex rounded-md border border-gray-300 px-4 py-2 transition-colors focus-within:border-blue focus:outline-none">
         <Input
           ref={ref}
           value={input}

--- a/pages/index.js
+++ b/pages/index.js
@@ -39,28 +39,28 @@ export function HomePage({ cards, hero, forceAppArmorTest = false }) {
         <Divider />
 
         <div className={containerClasses}>
-          <Heading level={2}>
+          <Heading level={2} className="text-uog-black">
             Our Latest News and Events
           </Heading>
           <SpotlightCards cards={cards} />
         </div>
 
         <div className={containerClasses}>
-          <Heading level={2}>
+          <Heading level={2} className="text-uog-black">
             Study Here
           </Heading>
           <StudyHere />
         </div>
 
         <div className={containerClasses}>
-          <Heading level={2}>
+          <Heading level={2} className="text-uog-black">
             How We Rank Among the World
           </Heading>
           <Rankings />
         </div>
 
         <div className={containerClasses}>
-          <Heading level={2}>
+          <Heading level={2} className="text-uog-black">
             Our Three Campuses
           </Heading>
           <ThreeCampuses />

--- a/pages/programs/certificate-and-diploma/index.js
+++ b/pages/programs/certificate-and-diploma/index.js
@@ -22,9 +22,9 @@ export default function ProgramsCertificateAndDiploma({ programs, types }) {
     <Layout metadata={{ title: "Certificates and Diplomas" }}>
       <Container centered>
         <Heading level={1}>Certificates and Diplomas at the University of Guelph</Heading>
-
-        <ProgramSearch programs={programs} types={types} />
       </Container>
+
+      <ProgramSearch programs={programs} types={types} />
     </Layout>
   );
 }

--- a/pages/programs/continuing-education/index.js
+++ b/pages/programs/continuing-education/index.js
@@ -22,9 +22,9 @@ export default function ProgramsContinuingEducation({ programs, types }) {
     <Layout metadata={{ title: "Continuing Education" }}>
       <Container centered>
         <Heading level={1}>Continuing Education at the University of Guelph</Heading>
-
-        <ProgramSearch programs={programs} types={types} />
       </Container>
+
+      <ProgramSearch programs={programs} types={types} />
     </Layout>
   );
 }

--- a/pages/programs/graduate/index.js
+++ b/pages/programs/graduate/index.js
@@ -19,9 +19,9 @@ export default function ProgramsGraduate({ programs, types, degreeTypes }) {
     <Layout metadata={{ title: "Graduate Programs" }}>
       <Container centered>
         <Heading level={1}>Graduate Programs at the University of Guelph</Heading>
-
-        <ProgramSearch programs={programs} types={types} degreeTypes={degreeTypes} />
       </Container>
+
+      <ProgramSearch programs={programs} types={types} degreeTypes={degreeTypes} />
     </Layout>
   );
 }

--- a/pages/programs/undergraduate/index.js
+++ b/pages/programs/undergraduate/index.js
@@ -33,9 +33,9 @@ export default function ProgramsUndergraduate({ programs, types }) {
     <Layout metadata={{ title: "Undergraduate Programs" }}>
       <Container centered>
         <Heading level={1}>Undergraduate Programs at the University of Guelph</Heading>
-
-        <ProgramSearch programs={programs} types={types} />
       </Container>
+
+      <ProgramSearch programs={programs} types={types} />
     </Layout>
   );
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -136,7 +136,7 @@ module.exports = {
         "chevron-right": '"\\f054"',
       },
       backgroundImage: {
-        divider: `linear-gradient(90deg, #000 0%, #000 33.33%, ${colors['uog-red']} 33.33%, ${colors['uog-red']} 66.66%, ${colors['uog-yellow']} 66.66%, ${colors['uog-yellow']} 100%)`,
+        divider: `linear-gradient(90deg, ${colors['uog-red']} 0%, ${colors['uog-red']} 33.33%, ${colors['uog-yellow']} 33.33%, ${colors['uog-yellow']} 66.66%, ${colors['uog-black']} 66.66%, ${colors['uog-black']} 100%)`,
       },
       aria: {
         "page-current": 'current="page"',


### PR DESCRIPTION
# Summary of changes
As per feedback from Linda:

**UGNext Homepage**
- H1 header: margin-top: 4rem. But only on this page!!
- h2 header: make them --uog-black. But only on this page!!
- horizontal rule: colours should be in this order = red, yellow, black

 **UGNext Program Search**
- Correct the top and bottom margin on the h1 to match what's on the basic pages.
- Can we apply the original design concept styles to the filter and tabs section? See design concept image titled "future-design-of-program-search.png" in Raza's Azure ticket https://dev.azure.com/uofgcpa/U%20of%20G%20Website%20Redesign/_workitems/edit/835/
- Change the tab focus colour to the same colour as the darker grey bar on the program cards.

## Frontend
- Add `mt-[4rem]` class to homepage h1
- Add `text-uog-black` class to homepage h2s
- Change colour order for `divider` to red-yellow-black
- Update hover colours in `navigation.js`
- Add `bg-uog-yellow` to program search bar
- Reformat and reposition program search bar

# Test Plan
- Go to https://br-next.netlify.app/ and verify the above changes are present
- Go to https://br-next.netlify.app/programs/undergraduate and verify the above changes are present. Also verify that program searches continue to work as expected