### PR TITLE
Re-add sizes to spotlight cards to improve performance

### DIFF
--- a/components/card.js
+++ b/components/card.js
@@ -35,6 +35,7 @@ export const Card = ({ href, image, title, footer, className, centered, children
               blurDataURL={image?.blurred}
               sizes={image?.sizes}
               className={twMerge("object-cover", image?.className)}
+              quality={image?.quality || 75}
             />
           </div>
         </div>

--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -21,6 +21,7 @@ export const SpotlightCards = ({ cards }) => (
             card.thumbnailImageCrop === "left" && "object-left",
             card.thumbnailImageCrop === "center" && "object-center"
           ),
+          sizes: "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw",
         }}
       />
     ))}

--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -22,6 +22,7 @@ export const SpotlightCards = ({ cards }) => (
             card.thumbnailImageCrop === "center" && "object-center"
           ),
           sizes: "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw",
+          quality: 100,
         }}
       />
     ))}


### PR DESCRIPTION
# Summary of changes
Re-add the sizes attribute for news items

## Frontend
Re-add the sizes attribute for news items

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Visually check the spotlight cards to see if the quality visibly decreases
1. Test the performance of the homepage on production vs the deployment (it says up 17 from production on the lighthouse automatic test). When I check manually, I'm seeing increases as well:
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/b884f57a-73c5-4cbb-a378-6f17f7d60f35" />
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/0d88b8f6-511e-412b-b78a-ddcae020ac5b" />
