### PR TITLE
Use Drupal Image Styles for Spotlight Cards

### DIFF
--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -11,16 +11,11 @@ export const SpotlightCards = ({ cards }) => (
         href={card.url.url}
         centered
         image={{
-          src: card.image.image.url,
-          alt: card.image.image.alt,
-          width: card.image.image.width,
-          height: card.image.image.height,
-          className: twJoin(
-            "aspect-[3/2] w-full",
-            card.thumbnailImageCrop === "right" && "object-right",
-            card.thumbnailImageCrop === "left" && "object-left",
-            card.thumbnailImageCrop === "center" && "object-center"
-          ),
+          src: card.image.url,
+          alt: card.image.alt,
+          width: card.image.width,
+          height: card.image.height,
+          className: "aspect-[3/2] w-full",
         }}
       />
     ))}

--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -16,6 +16,7 @@ export const SpotlightCards = ({ cards }) => (
           width: card.image.width,
           height: card.image.height,
           className: "aspect-[3/2] w-full",
+          sizes: "(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw",
         }}
       />
     ))}

--- a/data/drupal/home/index.js
+++ b/data/drupal/home/index.js
@@ -52,9 +52,24 @@ export const getSpotlightCards = async (status, hero) => {
         id: id,
       });
 
+      const card = data.spotlightRevisions.results?.[0];
+
+      if (!card) {
+        throw new Error(`Failed to fetch spotlight card ${id} data.`);
+      }
+
+      // The image is an array of variations, so we need to find the one that matches the thumbnailImageCrop.
+      const image = card.image?.image?.variations?.find((variation) => {
+        return variation.name.toLowerCase().includes(card.thumbnailImageCrop);
+      }) ?? {};
+
       return {
         id: id,
-        ...(data.spotlightRevisions.results?.[0] ?? {}),
+        ...card,
+        image: {
+          alt: card.image.image.alt,
+          ...image
+        }
       };
     })
   );

--- a/data/drupal/home/spotlight-card.graphql
+++ b/data/drupal/home/spotlight-card.graphql
@@ -1,14 +1,17 @@
 query SpotlightCard($status: Boolean = false, $id: String = "") {
-  spotlightRevisions(filter: { status: $status, id: $id }, pageSize: 1) {
+  spotlightRevisions(filter: {status: $status, id: $id}, pageSize: 1) {
     results {
       ... on NodeSpotlight {
         image {
           ... on MediaImage {
             image {
               alt
-              height
-              width
-              url
+              variations(styles: [SPOTLIGHT_CARD_LEFT_ALIGNED, SPOTLIGHT_CARD_CENTER_ALIGNED, SPOTLIGHT_CARD_RIGHT_ALIGNED]) {
+                url
+                width
+                height
+                name
+              }
             }
           }
         }


### PR DESCRIPTION
# Summary of changes
I added 3 new image styles on Drupal which crop the image to 600 by 400 and crops to left, center and right respectively.

This ensures we aren't loading wide images for the spotlight cards, hopefully improving performance.

## Frontend
- Updated data/drupal/home/spotlight-card.graphql to retrieve new variations
- Updated data/drupal/home/index.js to select correct image variation based on thumbnailImageCrop
- Updated components/home/spotlight-cards.js to use new data

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
- Added new image styles: Spotlight Card Left Aligned, Spotlight Card Center Aligned, Spotlight Card Right Aligned
- Updated GraphQL Compose settings to enable new image styles

# Test Plan

Multidev: https://rm-img-styl-chug.pantheonsite.io
Deploy preview: https://deploy-preview-67--ugnext.netlify.app/

1. Go to homepage
2. Ensure spotlight cards appear correctly