### PR TITLE
Set default wc_version to 2.x.x

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from "next/document";
 import Script from "next/script";
 
 const CDN_BASE = process.env.NEXT_PUBLIC_UOFG_WC_CDN_BASE_URL?.trim() || "https://cdn.jsdelivr.net/npm";
-const UOFG_WEB_COMPONENTS_BASE = `@uoguelph/web-components@${process.env.NEXT_PUBLIC_UOFG_WC_VERSION?.trim() || "1.x.x"}/dist/uofg-web-components`;
+const UOFG_WEB_COMPONENTS_BASE = `@uoguelph/web-components@${process.env.NEXT_PUBLIC_UOFG_WC_VERSION?.trim() || "2.x.x"}/dist/uofg-web-components`;
 
 export default function Document() {
   return (


### PR DESCRIPTION
# Summary of changes
Set default wc_version to 2.x.x

## Frontend
Set default wc_version to 2.x.x

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/a

# Test Plan

1. Confirm build completes