### PR TITLE
Update study-here card titles and URLs

### DIFF
--- a/components/home/study-here.js
+++ b/components/home/study-here.js
@@ -50,8 +50,8 @@ export const StudyHere = () => {
         blurred: lifelong.blurDataURL,
         alt: "Kathryn Knowles & Jenna Schamowski working with bee hives",
       },
-      title: "Lifelong Learning",
-      url: "https://opened.uoguelph.ca/",
+      title: "Continuing Studies",
+      url: "https://www.uoguelph.ca/continuing-studies/",
       caption: "Kathryn Knowles & Jenna Schamowski - Environmental Sciences",
     },
   ];


### PR DESCRIPTION
# Summary of changes
Update URL and Title for Continuing Studies in Study Here section

## Frontend
- Updated data in study-here.js

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to homepage https://deploy-preview-79--ugnext.netlify.app/
2. Scroll to study here section
3. Ensure URL and text are updated