### PR TITLE
Use `uuid` instead of `id`

### DIFF
--- a/data/drupal/basic-pages/get-page-id.graphql
+++ b/data/drupal/basic-pages/get-page-id.graphql
@@ -3,7 +3,7 @@ query GetPageID($url: String!) {
     ... on RouteInternal {
       entity {
         ... on NodePage {
-          id
+          id: uuid
         }
       }
     }

--- a/data/drupal/custom-footer.graphql
+++ b/data/drupal/custom-footer.graphql
@@ -3,7 +3,7 @@
 
 fragment CustomFooter on NodeCustomFooter {
   __typename
-  id
+  id: uuid
   title
   body {
     processed

--- a/data/drupal/home/spotlight-card-ids.graphql
+++ b/data/drupal/home/spotlight-card-ids.graphql
@@ -2,7 +2,7 @@ query SpotlightCardIDs($status: Boolean = null, $page: Int = 0) {
   spotlightRevisions(filter: { rank: [], status: $status }, page: $page, pageSize: 5) {
     results {
       ... on NodeSpotlight {
-        id
+        id: uuid
       }
     }
   }

--- a/data/drupal/home/spotlight-hero.graphql
+++ b/data/drupal/home/spotlight-hero.graphql
@@ -2,7 +2,7 @@ query SpotlightHero($status: Boolean = null) {
   spotlightRevisions(pageSize: 1, filter: { rank: ["1"], status: $status }) {
     results {
       ... on NodeSpotlight {
-        id
+        id: uuid
         caption
         captionAlignment
         thumbnailImageCrop


### PR DESCRIPTION
# Summary of changes

Updated GraphQL queries to replace `id` with `uuid` as entity id is now enabled in drupal and uuid is no longer under `id`

## Frontend
- Updated all GraphQL queries that request id to request uuid aliased as id instead,

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
- Enabled entity id in GraphQL Compose settings.

# Test Plan

1. Go to [preview link](https://deploy-preview-81--ugnext.netlify.app/).
2. Test various pages: home page, basic pages, etc.
3. Everything should be the same.