### PR TITLE
Add unique `id` to Spotlight Cards and Hero

### DIFF
--- a/components/card.js
+++ b/components/card.js
@@ -4,11 +4,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import Image from "next/image";
 
-export const Card = ({ href, image, title, footer, className, centered, children }) => {
+export const Card = ({ id, href, image, title, footer, className, centered, children }) => {
   const Tag = href ? UnstyledLink : "div";
 
   return (
     <Tag
+      id={id}
       className={twMerge(
         "group flex flex-col justify-center transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light-blue focus-visible:ring-offset-2",
         !image && href && "hover:scale-105 focus-visible:scale-105",

--- a/components/hero.js
+++ b/components/hero.js
@@ -8,7 +8,7 @@ import { EmbeddedVideo } from "@/components/embedded-video";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlay } from "@awesome.me/kit-7993323d0c/icons/classic/solid";
 
-export const Hero = ({ variant = "spotlight", image, video, title, caption, button, alignment }) => {
+export const Hero = ({ id, variant = "spotlight", image, video, title, caption, button, alignment }) => {
   return (
     <div className={twJoin("relative flex w-full flex-col overflow-hidden", variant !== "spotlight" && " h-fit")}>
       <Image
@@ -51,6 +51,7 @@ export const Hero = ({ variant = "spotlight", image, video, title, caption, butt
               {caption && <span className="text-xl">{caption}</span>}
               {button && (
                 <Button
+                  id={id}
                   color="yellow"
                   href={button?.href}
                   className={twJoin(

--- a/components/home/spotlight-cards.js
+++ b/components/home/spotlight-cards.js
@@ -6,6 +6,7 @@ export const SpotlightCards = ({ cards }) => (
     {cards.map((card, index) => (
       <Card
         key={card.id}
+        id={`uofg-homepage-spotlight-card-${index + 2}`}
         className={`h-full spotlight-card-rank-${index + 2}`}
         title={<span className="my-auto w-full text-center text-[2.2rem] leading-[3rem] font-bold">{card.title}</span>}
         href={card.url.url}

--- a/components/home/spotlight-hero.js
+++ b/components/home/spotlight-hero.js
@@ -3,6 +3,7 @@ import { twJoin } from "tailwind-merge";
 
 export const SpotlightHero = ({ hero }) => (
   <Hero
+    id={`uofg-homepage-spotlight-hero`}
     variant="spotlight"
     title={<h2 className="mt-0">{hero.title}</h2>}
     image={{


### PR DESCRIPTION
# Summary of changes
Added a unique id to spotlight cards and hero button, to make it easier for targeting in analytics.

## Frontend
- Updated Card and Hero component to accept id
- Added id to spotlight-card and spotlight-hero

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to https://deploy-preview-91--test-ugnext.netlify.app/
2. Ensure unique ids appear on hero button, and spotlight card a tags.