### PR TITLE
Ovc news front

### DIFF
--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/ovc/news/[...slug].js",
+          destination: "/ovc/news/node/{ID}",
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/ovc/news/[...slug]",
+          destination: "/ovc/news/[...slug].js",
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/ovc/news/",
+          destination: "/ovc/news/node/[...slug]",
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/ovc/news/node/{ID}",
+          destination: "/ovc/news/node/" + context.params.slug.join("/"),
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/ovc/news/node/[...slug]",
+          destination: "/node/[...slug]",
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -38,13 +38,13 @@ export async function getStaticProps(context) {
         },
       };
     //  For LegacyNews (Articles) redirect to /ovc-news/
-    // case "NodeArticle":
-    //   return {
-    //     redirect: {
-    //       destination: "/node/",
-    //       permanent: true,
-    //     },
-    //   };
+    case "NodeArticle":
+      return {
+        redirect: {
+          destination: "/ovc/news/",
+          permanent: true,
+        },
+      };
     // Fallback to showing 404 if we haven't defined redirect logic for a node type.
     default:
       return {

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/node/[...slug]",
+          destination: "/node/",
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -41,7 +41,7 @@ export async function getStaticProps(context) {
     case "NodeArticle":
       return {
         redirect: {
-          destination: "/ovc/news/",
+          destination: "/ovc/news/[...slug]",
           permanent: true,
         },
       };

--- a/pages/node/[...slug].js
+++ b/pages/node/[...slug].js
@@ -38,13 +38,13 @@ export async function getStaticProps(context) {
         },
       };
     //  For LegacyNews (Articles) redirect to /ovc-news/
-    case "NodeArticle":
-      return {
-        redirect: {
-          destination: "/node/",
-          permanent: true,
-        },
-      };
+    // case "NodeArticle":
+    //   return {
+    //     redirect: {
+    //       destination: "/node/",
+    //       permanent: true,
+    //     },
+    //   };
     // Fallback to showing 404 if we haven't defined redirect logic for a node type.
     default:
       return {


### PR DESCRIPTION
# Summary of changes
change the default for preview location on drupal side. 

Note this change is needed for when the Drupal Multidev is ready but will have no affect on the front end until it is ready.


## Frontend
change to pages/node/[...slug].js

    //  For LegacyNews (Articles) redirect to /ovc-news/
    case "NodeArticle":
      return {
        redirect: {
          destination: "/ovc/news/node/" + context.params.slug.join("/"),
          permanent: true,
        },
      };

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
No changes at this time - will be a separate PR for this 

# Test Plan

Go to any news item on https://ovcnewstrig-chug.pantheonsite.io/

Such as https://ovcnewstrig-chug.pantheonsite.io/node/4883 and it should preview in the frame.