### PR TITLE
Fixing OVC footer and using linkset for menus

### DIFF
--- a/app/ovc/page.tsx
+++ b/app/ovc/page.tsx
@@ -6,6 +6,7 @@ import { OVCCards } from "@/components/client/ovc/ovc-cards";
 import { OVCFeaturedNews } from "@/components/client/ovc/ovc-featured-news";
 import { getFeaturedNewsArticles } from "@/data/drupal/ovc-news";
 import { Metadata } from "next";
+import { OVCFooter } from "@/components/client/ovc/ovc-footer";
 
 export const metadata: Metadata = {
   title: "Ontario Veterinary College",
@@ -29,11 +30,14 @@ export default async function OVCHome() {
     <BasicPage
       id={route.entity.id}
       post={
-        <Container>
-          {/* @ts-ignore */}
-          <OVCFeaturedNews articles={featuredNews} />
-          <OVCCards />
-        </Container>
+        <>
+          <Container>
+            {/* @ts-ignore */}
+            <OVCFeaturedNews articles={featuredNews} />
+            <OVCCards />
+          </Container>
+          <OVCFooter />
+        </>
       }
     />
   );

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "ugnext",
       "dependencies": {
         "@awesome.me/kit-7993323d0c": "^1.0.10",
+        "@drupal/linkset": "^1.0.3",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.3",
         "@netlify/plugin-nextjs": "^5.12.0",
@@ -129,6 +130,8 @@
     "@babel/types": ["@babel/types@7.28.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg=="],
 
     "@discoveryjs/json-ext": ["@discoveryjs/json-ext@0.5.7", "", {}, "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="],
+
+    "@drupal/linkset": ["@drupal/linkset@1.0.3", "", {}, "sha512-BMusbcNKAVV7v8vhOP1cfM0wkAL8iwARc9zU1R2VxEn85f8F08hHY4IbFB5axTgfMEED4QJJCiXrOGZwN3HMLQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.4.4", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.3", "tslib": "^2.4.0" } }, "sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g=="],
 

--- a/components/client/ovc/ovc-footer.js
+++ b/components/client/ovc/ovc-footer.js
@@ -29,7 +29,10 @@ export const OVCFooter = () => {
         <div className="grid gap-4 grid-cols-1 md:grid-cols-3 mt-8">
           <div>
             <div className="md:flex flex-wrap gap-3 mt-8">
-              <a href="https://instagram.com/ontvetcollege/" className="btn btn-outline-secondary text-dark-social">
+              <a
+                href="https://instagram.com/ontvetcollege/"
+                className="border border-gray-400 rounded px-2 py-1 text-gray-700 hover:bg-gray-200 transition"
+              >
                 <span className="sr-only">Connect with OVC on Instagram</span>
                 <i className="fa-brands fa-instagram text-xl p-1" aria-hidden="true"></i>
               </a>

--- a/components/server/header.tsx
+++ b/components/server/header.tsx
@@ -1,5 +1,5 @@
 import { Header as HeaderComponent, HeaderLink, HeaderMenu, HeaderMenuItem } from "@uoguelph/react-components/header";
-import { getMenuByName } from "@/data/drupal/menu";
+import { getMenuByName, getMenuByNameLinkset } from "@/data/drupal/menu";
 
 type Menu = NonNullable<Awaited<ReturnType<typeof getMenuByName>>>;
 type MenuItem = Menu["items"][number];
@@ -21,7 +21,7 @@ async function HeaderSubNavigationItem({ item }: { item: MenuItem }) {
 }
 
 export async function Header({ name }: { name?: string }) {
-  const menu = name ? await getMenuByName(name) : null;
+  const menu = name ? await getMenuByNameLinkset(name) : null;
 
   if (!menu) {
     return <HeaderComponent></HeaderComponent>;

--- a/data/drupal/menu.ts
+++ b/data/drupal/menu.ts
@@ -1,5 +1,7 @@
 import { gql } from "@/lib/graphql";
 import { query } from "@/lib/apollo";
+import { parse, type LinksetInterface } from "@drupal/linkset";
+import type { MenuFragment } from "@/lib/graphql/types";
 
 export const MENU_CONTENT_FRAGMENT = gql(/* gql */ `
   fragment MenuItem on MenuItem {
@@ -39,4 +41,62 @@ export async function getMenuByName(name: string) {
   });
 
   return data?.menu;
+}
+
+export async function getMenuByNameLinkset(menuName: string) {
+  const name = menuName.toLowerCase().replaceAll("_", "-");
+
+  if (!name || name === "no-menu") {
+    return null;
+  }
+
+  const response = await fetch(`${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}/system/menu/${name}/linkset`);
+
+  if (!response.ok) {
+    console.error(`Failed to fetch menu ${name}: ${response.statusText}`);
+    return null;
+  }
+
+  const data = await response.text();
+  let linkset: LinksetInterface;
+
+  try {
+    linkset = parse(data);
+  } catch (error) {
+    console.error(`Error parsing linkset for menu ${name}:`, error);
+    return null;
+  }
+
+  const menu: MenuFragment = { __typename: "Menu", items: [] };
+  const links = linkset.elements.filter((link) => {
+    if ("hierarchy" in link.attributes && Array.isArray(link.attributes.hierarchy)) {
+      return link.attributes.hierarchy.length < 3;
+    }
+
+    return false;
+  });
+
+  for (const link of links) {
+    const href = link.href;
+    const title = link.attributes.title ?? "Untitled";
+    const hierarchy = (link.attributes.hierarchy ?? []) as string[];
+
+    if (hierarchy.length === 1) {
+      menu.items.push({
+        __typename: "MenuItem",
+        title,
+        url: href,
+        children: [],
+      });
+    } else if (hierarchy.length === 2) {
+      const index = Number.parseInt(hierarchy[0]);
+      menu.items[index]?.children?.push({
+        __typename: "MenuItem",
+        title,
+        url: href,
+      });
+    }
+  }
+
+  return menu;
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@awesome.me/kit-7993323d0c": "^1.0.10",
+    "@drupal/linkset": "^1.0.3",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.3",
     "@netlify/plugin-nextjs": "^5.12.0",


### PR DESCRIPTION
# Summary of changes
Add OVC custom footer to the OVC home page.
Switch to using linkset instead of graphql for menus

## Frontend
- Added getMenuByNameLinkset to data/drupal/menu.ts
- Updated header.tsx to use getMenuByNameLinkset instead of getMenuByName
- Added OVCFooter component to app/ovc/page.tsx

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to https://deploy-preview-113--ugnext.netlify.app/ovc and ensure header menu and custom footer appear.