### PR TITLE
Change order in undergraduate admission requirements, and fix bug with international 404

### DIFF
--- a/data/drupal/undergraduate-admission-requirements.ts
+++ b/data/drupal/undergraduate-admission-requirements.ts
@@ -343,7 +343,7 @@ async function getUndergraduateAdmissionRequirementPageContentByID(ids: string[]
           sectionsMap.set(type, []);
         }
 
-        sectionsMap.get(type)?.push(section);
+        sectionsMap.get(type)?.unshift(section);
       }
     }
   }


### PR DESCRIPTION
# Summary of changes
Changed the order in which sections appear on the page. Fixed a bug where if international locations are selected in the filter, the filter would 404.

## Frontend
- Updated route.ts to fallback to current revision if latest failed to fetch content.
- Used unshift instead of push in undergraduate-admission-requirement.ts

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Ensure https://deploy-preview-121--ugnext.netlify.app/programs/undergraduate/requirements/high-school/afghanistan/applied-human-nutrition no longer 404 in draft mode/dev server.