### PR TITLE
Update wording in Co-op admission note to use "subject" instead of "program"

### DIFF
--- a/components/client/programs/undergraduate/admission-requirements-sections.tsx
+++ b/components/client/programs/undergraduate/admission-requirements-sections.tsx
@@ -31,7 +31,7 @@ export function AdmissionRequirementsSections({
     <>
       {program.type.some((type) => type.name === "Co-op") && (
         <Typography type="body" as="span" className="block! italic">
-          This program is offered with and without{" "}
+          This subject is offered with and without{" "}
           <Link href="/experiential-learning/future-students/co-op-programs">co-op</Link>.
         </Typography>
       )}


### PR DESCRIPTION
# Summary of changes
See title

## Frontend
- Updated admission-requirements-sections.tsx 

- [ ] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [ ] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan
1. Go to any requirement