### PR TITLE
New menu fix - for parent item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+next-env.d.ts
 
 # production
 /build
@@ -18,6 +19,7 @@
 # misc
 .DS_Store
 *.pem
+.vs
 
 # debug
 npm-debug.log*

--- a/data/drupal/menu.ts
+++ b/data/drupal/menu.ts
@@ -76,6 +76,9 @@ export async function getMenuByNameLinkset(menuName: string) {
     return false;
   });
 
+  // Track which parents have had their URL added to children
+  const parentUrlAdded: Record<number, boolean> = {};
+
   for (const link of links) {
     const href = link.href;
     const title = link.attributes.title ?? "Untitled";
@@ -90,6 +93,19 @@ export async function getMenuByNameLinkset(menuName: string) {
       });
     } else if (hierarchy.length === 2) {
       const index = Number.parseInt(hierarchy[0]);
+      // Add parent item with URL as the first child if not already added
+      if (
+        menu.items[index] &&
+        menu.items[index].url &&
+        !parentUrlAdded[index]
+      ) {
+        menu.items[index].children.unshift({
+          __typename: "MenuItem",
+          title: menu.items[index].title,
+          url: menu.items[index].url,
+        });
+        parentUrlAdded[index] = true;
+      }
       menu.items[index]?.children?.push({
         __typename: "MenuItem",
         title,


### PR DESCRIPTION
# Summary of changes
Added the parent to the menu (in the grey bar)


## Frontend
List all significant changes to Next.js code

Added code to menu.ts to put the parent item to the drop down menus.

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
List all significant changes to the Drupal site (e.g., new fields, content types, modules, etc). If adding new fields, try to include help text to ensure users understand how to use the fields.

# Test Plan

Insert steps. Include URLs of Netlify test site and Drupal multidev.

https://deploy-preview-160--ugnext.netlify.app/ovc - the parent menu is in the dropdown
check any other page 
