### PR TITLE
Refactor Draft Mode UI by adding the ability to manually revalidate a page

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import { draftMode } from "next/headers";
 import { Bitter, DM_Sans } from "next/font/google";
 import "@/styles/globals.css";
 import "@uoguelph/web-components/style";
-import { Button } from "@uoguelph/react-components/button";
+import { DraftModeBanner } from "@/components/client/draft-mode-banner";
 
 const dmSans = DM_Sans({
   subsets: ["latin"],
@@ -59,15 +59,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
         <AppArmor />
 
-        {isDraftMode && (
-          <div className="sticky left-0 top-0 z-20 flex h-fit w-full items-center justify-center gap-2 bg-red p-2 text-center text-base font-bold text-white">
-            <span>You are currently in Draft Mode.</span>
-
-            <Button color="yellow" className="p-2" href="/api/disable-draft" as="a">
-              Disable Draft Mode
-            </Button>
-          </div>
-        )}
+        {isDraftMode && <DraftModeBanner />}
 
         {children}
       </body>

--- a/components/client/draft-mode-banner.tsx
+++ b/components/client/draft-mode-banner.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Button } from "@uoguelph/react-components/button";
+import { usePathname } from "next/navigation";
+
+export function DraftModeBanner() {
+  const pathname = usePathname();
+  return (
+    <div className="sticky left-0 top-0 z-20 flex h-fit w-full items-center justify-center gap-2 bg-red p-2 text-center text-base font-bold text-white">
+      <span>You are currently in Draft Mode.</span>
+
+      <Button color="yellow" className="p-2" href="/api/disable-draft" as="a">
+        Disable Draft Mode
+      </Button>
+
+      <Button color="yellow" className="p-2" href={`/api/revalidate?path=${pathname}`} as="a">
+        Revalidate Page
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary of changes
Revalidation is only automatically triggered when the node associated with the page is updated, if some content linked to it is updated, i.e. a media item has its alt text updated, etc. The revalidation isn't triggered.

So I've added the ability to manually trigger revalidation to cover these situations.

## Frontend
- Extract draft mode banner into it's own component.
- Add a button for manual revalidation
- Update the revalidation endpoint to allow authorization through the secret or if the user is in draft mode.

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Go to https://api.liveugconthub.uoguelph.dev/
2. Select a spotlight item
3. The preview should enter you into draft mode
4. You should see the banner at the top of the preview page, and there should be a new revalidate button.
5. 