### PR TITLE
Remove next-env.d.ts from version control

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Summary of changes
Despite adding `next-env.d.ts` to `.gitignore` it keeps showing up as modified because it was likely committed by accident at some point. It should not be in version control so this PR removes it altogether.