### PR TITLE
Render Statistic Icon

### DIFF
--- a/components/client/widgets/statistics.js
+++ b/components/client/widgets/statistics.js
@@ -21,6 +21,9 @@ export function StatisticsWidget({ data }) {
       {data?.content.map((statistic, index) => {
         return (
           <StatisticsItem key={index}>
+            {statistic?.fontAwesomeIcon && variant === "light-grey" && (
+              <i className={`${statistic.fontAwesomeIcon} fa-4x pt-6 -mb-6`}></i>
+            )}
             <StatisticsItemValue>{statistic?.value}</StatisticsItemValue>
             <StatisticsItemRepresents>
               <HtmlParser html={statistic?.represents?.processed} />


### PR DESCRIPTION
# Summary of changes
Fixes Issue #140 

## Frontend
Update the `statistics.js` widget so the Font Awesome icon renders if it:
- is defined
- the Statistic variant chosen in the backend is "Light Blue"

## Backend
N/A

## Checklist
- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to https://deploy-preview-166--ugnext.netlify.app/arts/gap and verify the same icons from the [gus version](https://ugconthub.netlify.app/arts/gap/) are visible here as well
- Go to https://deploy-preview-154--ugnext.netlify.app/cbs/about-cbs/strategic-plan and verify the icons do _not_ display (as they do on the [gus version](https://ugconthub.netlify.app/cbs/about-cbs/strategic-plan/)) since the statistic variant isn't "Light Blue"

## Known Issues
- The grid layout is different, i.e. ugnext shows more in a row than gus
- This is a temporary/MVP fix - the permanent solution will likely require an overhaul of [the original Statistics component from uog-components](https://github.com/ccswbs/uofg-components/tree/main/packages/react-components/src/components/statistics) 