### PR TITLE
Update Testimonial Slider colour and display testimonial type

### DIFF
--- a/components/client/widgets/testimonial-slider.js
+++ b/components/client/widgets/testimonial-slider.js
@@ -58,7 +58,7 @@ export function TestimonialSliderWidget({ data }) {
               <MediaCaption
                 key={testimonial.id}
                 position="left"
-                size={"medium"}
+                size="medium"
                 src={image?.url}
                 width={image?.width}
                 height={image?.height}
@@ -66,8 +66,8 @@ export function TestimonialSliderWidget({ data }) {
                 className="[&_.uofg-media-caption-media]:rounded-full [&_.uofg-media-caption-media]:aspect-square h-full"
                 as="img"
               >
-                <Blockquote hideQuotationMarks className="justify-center min-h-full">
-                  <BlockquoteContent className="text-left text-6xl">
+                <Blockquote hideQuotationMarks>
+                  <BlockquoteContent className="text-left text-xl">
                     <HtmlParser html={testimonial?.body?.processed} />
                   </BlockquoteContent>
 


### PR DESCRIPTION
# Summary of changes
- Fixes #135 
- Use black for testimonial author name
- Add testimonial type (comma-separated) after author name
- Fix display when there is only one testimonial

## Frontend
- Use black for testimonial author name
- Add testimonial type (comma-separated) after author name
- Fix display when there is only one testimonial

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. View https://deploy-preview-168--ugnext.netlify.app/widget-examples#testimonial-slider
2. View single testimonial at https://deploy-preview-168--ugnext.netlify.app/cbs/about-cbs/strategic-plan
3. View other pages with testimonials (e.g., https://deploy-preview-168--ugnext.netlify.app/programs/crop-science)

# Caveats
~The single testimonial looks quite large with a single display~ (This has been updated to fix)