### PR TITLE
Display summary on profile page

### DIFF
--- a/components/server/profile.tsx
+++ b/components/server/profile.tsx
@@ -139,6 +139,7 @@ export async function Profile({ id, pre, post }: ProfileProps) {
             )}
           </div>
           {/* Parse and render the Body field */}
+          <HtmlParser key="profile-summary" html={content.body?.summary ?? ""} instructions={undefined} />
           <HtmlParser key="profile-body" html={content.body?.processed ?? ""} instructions={undefined} />
           
           {/* Render all Profile Sections in order (both regular parts and UniWeb parts) */}

--- a/data/drupal/profile.ts
+++ b/data/drupal/profile.ts
@@ -36,6 +36,7 @@ export const PROFILE_FRAGMENT = gql(/* gql */ `
     uniwebId
     body {
       processed
+      summary
     }
     customLink {
       title

--- a/lib/types/profile.ts
+++ b/lib/types/profile.ts
@@ -97,6 +97,7 @@ export interface FullProfile extends ProfileWithImage {
   };
   body?: {
     processed?: string;
+    summary?: string;
   };
   customLink?: ProfileCustomLink[];
   profileUnit?: ProfileUnit[];


### PR DESCRIPTION
# Summary of changes
Display summary on profile page
Fixes #179

## Frontend
Display summary on profile page

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Check /profile/mihai-nica-0 and confirm summary shows