### PR TITLE
Fix images not being rendered in Links Widget

### DIFF
--- a/components/client/widgets/links.js
+++ b/components/client/widgets/links.js
@@ -6,7 +6,7 @@ import NextLink from "next/link";
 import { tv } from "tailwind-variants";
 
 export function LinksWidget({ data }) {
-  const useCards = data?.links?.every((link) => Boolean(link.image));
+  const useCards = data?.links?.some((link) => Boolean(link.image));
   const classes = tv({
     slots: {
       container: "grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4",
@@ -27,15 +27,18 @@ export function LinksWidget({ data }) {
             centered
             key={link.url.title + index}
           >
-            <CardImage
-              as={Image}
-              src={link.image.image.url}
-              width={link.image.image.width}
-              height={link.image.image.height}
-              alt={link.image.image.alt}
-              className={classes.cardImage()}
-              sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-            />
+            {link.image?.image?.url && (
+              <CardImage
+                as={Image}
+                src={link.image.image.url}
+                width={link.image.image.width}
+                height={link.image.image.height}
+                alt={link.image.image.alt}
+                className={classes.cardImage()}
+                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+              />
+            )}
+
             <CardContent>
               <CardTitle className="my-auto text-center">{link.url.title}</CardTitle>
             </CardContent>


### PR DESCRIPTION
# Summary of changes
Fixes https://github.com/ccswbs/ugnext/issues/176

## Frontend
- Change the logic which determines whether the links widget should use cards or lists.
- Only render images in cards if a img url is present

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

1. Compare https://ugnext.netlify.app/ovc/crest to /ovc/crest and ensure links render as cards in deploy preview