### PR TITLE
Fix button layout, and H2 color

### DIFF
--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import parse, { HTMLReactParserOptions, Element, attributesToProps, domToReact, type DOMNode } from "html-react-parser";
-import React, { Fragment, useMemo } from "react";
+import React, { Fragment, useMemo, ReactNode, isValidElement } from "react";
 import { nanoid } from "nanoid";
 import { Typography } from "@uoguelph/react-components/typography";
 import { twMerge } from "tailwind-merge";
@@ -77,7 +77,7 @@ function hasAncestorWithClass(node: Element, className: string): boolean {
 
 function unwrapTags(children: React.ReactNode): React.ReactNode {
   return React.Children.map(children, (child) => {
-    if (child && typeof child !== "string" && (child.type === "span" || child.type === "strong")) {
+    if (child && isValidElement(child) && (child.type === "span" || child.type === "strong")) {
       return unwrapTags(child.props.children);
     }
     return child;

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -75,7 +75,7 @@ function hasAncestorWithClass(node: Element, className: string): boolean {
   return false;
 }
 
-function unwrapTags(children) {
+function unwrapTags(children: React.ReactNode): React.ReactNode {
   return React.Children.map(children, (child) => {
     if (typeof child !== "string" && (child.type === "span" || child.type === "strong")) {
       return unwrapTags(child.props.children);

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import parse, { HTMLReactParserOptions, Element, attributesToProps, domToReact, type DOMNode } from "html-react-parser";
-import React, { Fragment, useMemo, ReactNode, isValidElement } from "react";
+import React, { Fragment, useMemo, ReactNode, isValidElement, ReactElement } from "react";
 import { nanoid } from "nanoid";
 import { Typography } from "@uoguelph/react-components/typography";
 import { twMerge } from "tailwind-merge";
@@ -75,10 +75,13 @@ function hasAncestorWithClass(node: Element, className: string): boolean {
   return false;
 }
 
-function unwrapTags(children: React.ReactNode): React.ReactNode {
+function unwrapTags(children: ReactNode): ReactNode {
   return React.Children.map(children, (child) => {
-    if (child && isValidElement(child) && (child.type === "span" || child.type === "strong")) {
-      return unwrapTags(child.props.children);
+    if (child && isValidElement(child)) {
+      const element = child as ReactElement<any>; 
+      if (element.type === "span" || element.type === "strong") {
+        return unwrapTags(element.props.children);
+      }
     }
     return child;
   });

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -353,7 +353,7 @@ const defaultInstructions: ParserInstruction[] = [
         >
           {React.Children.map(children, (child) => {
             // Remove strong tags from headings
-            if (typeof child !== "string" && child.type === "strong") {
+            if (typeof child !== "string" && child.type === "strong" || child.type === "span") {
               return child.props.children;
             }
 

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -353,10 +353,12 @@ const defaultInstructions: ParserInstruction[] = [
         >
           {React.Children.map(children, (child) => {
             // Remove strong tags from headings
-            if (typeof child !== "string" && (child.type === "strong" || child.type === "span")) {
-              return child.props.children;
+            if (typeof child !== "string" && child.type === "span") {
+              if (typeof child !== "string" && child.type === "strong") {
+                 return child.props.children;
+              }
             }
-
+            
             return child;
           })}
         </Typography>

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -364,7 +364,7 @@ const defaultInstructions: ParserInstruction[] = [
           as={level}
           className={twMerge(index === 0 && "mt-0", className)}
         >
-          {cleanedChildren};
+          {cleanedChildren}
         </Typography>
       );
     },

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -77,7 +77,7 @@ function hasAncestorWithClass(node: Element, className: string): boolean {
 
 function unwrapTags(children: React.ReactNode): React.ReactNode {
   return React.Children.map(children, (child) => {
-    if (typeof child !== "string" && (child.type === "span" || child.type === "strong")) {
+    if (child && typeof child !== "string" && (child.type === "span" || child.type === "strong")) {
       return unwrapTags(child.props.children);
     }
     return child;

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -353,7 +353,7 @@ const defaultInstructions: ParserInstruction[] = [
         >
           {React.Children.map(children, (child) => {
             // Remove strong tags from headings
-            if (typeof child !== "string" && child.type === "strong" || child.type === "span") {
+            if (typeof child !== "string" && (child.type === "strong" || child.type === "span")) {
               return child.props.children;
             }
 

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -75,6 +75,15 @@ function hasAncestorWithClass(node: Element, className: string): boolean {
   return false;
 }
 
+function unwrapTags(children) {
+  return React.Children.map(children, (child) => {
+    if (typeof child !== "string" && (child.type === "span" || child.type === "strong")) {
+      return unwrapTags(child.props.children);
+    }
+    return child;
+  });
+}
+
 // Counter for td elements with rowspan to handle alternating colors
 let rowspanTdCounter = 0;
 
@@ -336,6 +345,7 @@ const defaultInstructions: ParserInstruction[] = [
       const level = node.tagName as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
       const className = typeof props.className === "string" ? props.className : "";
       const headingClass = className.match(/\bh[\d]\b/g);
+      const cleanedChildren = unwrapTags(children);
       let type = level;
 
       // Allow headings to appear smaller if needed
@@ -351,16 +361,7 @@ const defaultInstructions: ParserInstruction[] = [
           as={level}
           className={twMerge(index === 0 && "mt-0", className)}
         >
-          {React.Children.map(children, (child) => {
-            // Remove strong tags from headings
-            if (typeof child !== "string" && child.type === "span") {
-              if (typeof child !== "string" && child.type === "strong") {
-                 return child.props.children;
-              }
-            }
-            
-            return child;
-          })}
+          {cleanedChildren};
         </Typography>
       );
     },

--- a/components/client/widgets/button-section.js
+++ b/components/client/widgets/button-section.js
@@ -58,7 +58,7 @@ export const ButtonWidget = ({ data, column }) => {
         secondary: {
           button: "w-full mx-0",
         },
-        "call-to-action": { button: "text-2xl! py-4 px-10 min-w-[200px]" },
+        "call-to-action": {},
       },
       hasHeading: {
         true: {
@@ -129,13 +129,14 @@ export const ButtonSectionWidget = ({ data }) => {
       column: {
         primary: "flex flex-wrap px-0 mx-0",
         secondary: "flex-col px-0 mx-0",
-        "call-to-action": "flex-col items-center",
+        "call-to-action": "flex-wrap flex-row items-center",
       },
     },
   })({ column, section: context?.column ?? "primary" });
 
   return (
     <Container id={`button-section-${data.uuid}`} className={classes}>
+      <div className="basis-full h-0"></div>
       {buttons?.length > 0 && buttons.map((button) => <ButtonWidget key={button.id} column={column} data={button} />)}
     </Container>
   );

--- a/components/client/widgets/button-section.js
+++ b/components/client/widgets/button-section.js
@@ -58,7 +58,7 @@ export const ButtonWidget = ({ data, column }) => {
         secondary: {
           button: "w-full mx-0",
         },
-        "call-to-action": {},
+        "call-to-action": { button: "text-2xl! py-4 px-10 min-w-[200px]" },
       },
       hasHeading: {
         true: {

--- a/components/client/widgets/button-section.js
+++ b/components/client/widgets/button-section.js
@@ -97,10 +97,12 @@ export const ButtonWidget = ({ data, column }) => {
   return (
     <>
       {heading && (
+        <>
         <Typography id={`button-heading-${data.uuid}`} type="h3" as="h2" className={classes.heading()}>
           <HtmlParser html={heading} />
         </Typography>
         <div className="basis-full h-0"></div>
+        </>
       )}
 
       <Button

--- a/components/client/widgets/button-section.js
+++ b/components/client/widgets/button-section.js
@@ -100,6 +100,7 @@ export const ButtonWidget = ({ data, column }) => {
         <Typography id={`button-heading-${data.uuid}`} type="h3" as="h2" className={classes.heading()}>
           <HtmlParser html={heading} />
         </Typography>
+        <div className="basis-full h-0"></div>
       )}
 
       <Button
@@ -136,7 +137,6 @@ export const ButtonSectionWidget = ({ data }) => {
 
   return (
     <Container id={`button-section-${data.uuid}`} className={classes}>
-      <div className="basis-full h-0"></div>
       {buttons?.length > 0 && buttons.map((button) => <ButtonWidget key={button.id} column={column} data={button} />)}
     </Container>
   );

--- a/components/client/widgets/button-section.js
+++ b/components/client/widgets/button-section.js
@@ -132,7 +132,7 @@ export const ButtonSectionWidget = ({ data }) => {
       column: {
         primary: "flex flex-wrap px-0 mx-0",
         secondary: "flex-col px-0 mx-0",
-        "call-to-action": "flex-wrap flex-row items-center",
+        "call-to-action": "flex-wrap flex-row items-center justify-center",
       },
     },
   })({ column, section: context?.column ?? "primary" });

--- a/components/client/widgets/button-section.js
+++ b/components/client/widgets/button-section.js
@@ -4,6 +4,7 @@ import { Typography } from "@uoguelph/react-components/typography";
 import { Button } from "@uoguelph/react-components/button";
 import { HtmlParser } from "@/components/client/html-parser";
 import { tv } from "tailwind-variants";
+import { twMerge } from "tailwind-merge";
 import { Container } from "@uoguelph/react-components/container";
 import { useContext } from "react";
 import { SectionContext } from "@/components/client/section";
@@ -62,7 +63,7 @@ export const ButtonWidget = ({ data, column }) => {
       },
       hasHeading: {
         true: {
-          button: "text-2xl! py-4 px-10",
+          button: "py-4 px-10",
         },
         false: {
           button: "p-4",
@@ -97,17 +98,16 @@ export const ButtonWidget = ({ data, column }) => {
   return (
     <>
       {heading && (
-        <>
-        <Typography id={`button-heading-${data.uuid}`} type="h3" as="h2" className={classes.heading()}>
-          <HtmlParser html={heading} />
-        </Typography>
-        <div className="basis-full h-0"></div>
-        </>
+        <div className="basis-full">
+          <Typography id={`button-heading-${data.uuid}`} type="h3" as="h2" className={classes.heading()}>
+            <HtmlParser html={heading} />
+          </Typography>
+        </div>
       )}
 
       <Button
         id={`button-${data.uuid}`}
-        className={classes.button()}
+        className={twMerge(classes.button(), column === "call-to-action" && "text-2xl")}
         as={Link}
         href={url}
         color={color}


### PR DESCRIPTION
# Summary of changes
- H2 color back to Red (as previously)
- Buttons are now in the same row
- Partly fixes two issues (#174 , #139)
- Fixes #189

## Frontend
- Remove span and strong tags around h2, using a function
- Updated layout for buttons

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
n/a

# Test Plan

- Go to https://deploy-preview-184--ugnext.netlify.app/
- Check https://deploy-preview-184--ugnext.netlify.app/ovc/dvm/mentorship-and-opportunities and see if the headings are red.
- Check https://deploy-preview-184--ugnext.netlify.app/housing/communities/lennox-and-addington-hall to see if the buttons under "Residence is where..." are on the same line