### PR TITLE
Render Call to Action special region in primary section

### DIFF
--- a/components/client/widgets/section.js
+++ b/components/client/widgets/section.js
@@ -40,6 +40,9 @@ export function SectionWidget({ data }) {
       const column = columnName ? columnName.toLowerCase() : "";
 
       switch (column) {
+        case "call to action":
+          acc.primary.push(widget);
+          break;
         case "primary":
           acc.primary.push(widget);
           break;
@@ -128,6 +131,8 @@ export function SectionWidget({ data }) {
           equal={sectionClasses === "col-md-6"}
         />
       )}
+
+      
     </>
   );
 }

--- a/components/client/widgets/section.js
+++ b/components/client/widgets/section.js
@@ -131,8 +131,6 @@ export function SectionWidget({ data }) {
           equal={sectionClasses === "col-md-6"}
         />
       )}
-
-      
     </>
   );
 }


### PR DESCRIPTION
# Summary of changes
Fixes #186 
Render Call to Action special region in primary section (in order)

## Frontend
Render Call to Action special region in primary section (in order)

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Check /ovc/master-biomedical-sciences-mbs-clinical-studies/
2. Confirm button appears in correct order