### PR TITLE
Use h-auto on media text widget with no_body

### DIFF
--- a/components/client/widgets/media-text.js
+++ b/components/client/widgets/media-text.js
@@ -70,7 +70,7 @@ export function MediaTextWidget({ data }) {
       base: "col-span-1 h-full w-full",
       heading: "mt-0!",
       body: "",
-      no_body: "grid-cols-1",
+      no_body: "grid-cols-1 h-auto",
     },
     variants: {
       background: {


### PR DESCRIPTION
# Summary of changes
Fixes scenario where media and text widget has no body and ends up with too much space below it.
Fixes #174 

## Frontend
Use h-auto on media text widget with no_body

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
None

# Test Plan

1. Check https://deploy-preview-188--ugnext.netlify.app/ovc/dvm/mentorship-and-opportunities to see if issue is fixed
2. Check https://deploy-preview-188--ugnext.netlify.app/cbs/about-cbs/strategic-plan to confirm media and text widgets are still equal height
3. Check https://deploy-preview-188--ugnext.netlify.app/media-and-text-examples to see if anything looks odd