### PR TITLE
Use menus for breadcrumb route

### DIFF
--- a/components/server/basic-page.tsx
+++ b/components/server/basic-page.tsx
@@ -43,14 +43,14 @@ function PageHero({ content }: { content: NonNullable<PageContent> }) {
           )}
         </Hero>
 
-        <Breadcrumbs url={content.path ?? undefined} />
+        <Breadcrumbs url={content.path ?? undefined} primary_navigation={content.primaryNavigation?.menuName ?? undefined} />
       </>
     );
   }
 
   return (
     <>
-      <Breadcrumbs url={content.path ?? undefined} />
+      <Breadcrumbs url={content.path ?? undefined} primary_navigation={content.primaryNavigation?.menuName ?? undefined} />
 
       <Container>
         <Typography type="h1" as="h1">

--- a/components/server/breadcrumbs.tsx
+++ b/components/server/breadcrumbs.tsx
@@ -5,23 +5,23 @@ import {
 } from "@uoguelph/react-components/breadcrumbs";
 import { getRouteBreadcrumbs } from "@/data/drupal/route";
 
-export async function Breadcrumbs({ url }: { url?: string }) {
-  const breadcrumbs = url ? await getRouteBreadcrumbs(url) : [];
+export async function Breadcrumbs({ url, primary_navigation }: { url?: string, primary_navigation?: string }) {
+  const breadcrumbs = url ? await getRouteBreadcrumbs(url, primary_navigation) : [];
 
   return (
     <BreadcrumbsComponent className="text-base">
       <BreadcrumbHome href="/" />
 
-      {breadcrumbs?.map((breadcrumb) => {
+      {breadcrumbs?.map((breadcrumb, index) => {
         if ("url" in breadcrumb && breadcrumb.url) {
           return (
-            <Breadcrumb className="text-base" key={breadcrumb.url} href={breadcrumb.url}>
+            <Breadcrumb className="text-base" key={`${breadcrumb.url}-${index}`} href={breadcrumb.url}>
               {breadcrumb.title}
             </Breadcrumb>
           );
         }
 
-        return <Breadcrumb key={breadcrumb.title}>{breadcrumb.title}</Breadcrumb>;
+        return <Breadcrumb key={`${breadcrumb.title}-${index}`}>{breadcrumb.title}</Breadcrumb>;
       })}
     </BreadcrumbsComponent>
   );

--- a/data/drupal/route.ts
+++ b/data/drupal/route.ts
@@ -159,7 +159,7 @@ export async function getRoute(url: string) {
   }
 }
 
-export async function getRouteBreadcrumbs(url: string) {
+export async function getRouteBreadcrumbs(url: string, primary_navigation: string | undefined) {
   const { data, error } = await query({
     query: gql(/* gql */ `
       query RouteBreadcrumbs($path: String!, $revision: ID = "current") {
@@ -195,6 +195,9 @@ export async function getRouteBreadcrumbs(url: string) {
               }
               ... on NodePage {
                 title
+                primaryNavigation {
+                  menuName
+                }
               }
               ... on NodeProgram {
                 title
@@ -231,6 +234,15 @@ export async function getRouteBreadcrumbs(url: string) {
     case "RouteInternal":
       if (!data.route.entity || !("title" in data.route.entity)) {
         return null;
+      }
+
+      // If breadcrumb does not belong to primary_navigation, only show title
+      if(data.route.entity.__typename === "NodePage" && data.route.entity.primaryNavigation?.menuName !== primary_navigation){
+        return [
+          {
+            title: data.route.entity.title,
+          },
+        ];
       }
 
       if (!Array.isArray(data.route.breadcrumbs)) {

--- a/data/drupal/route.ts
+++ b/data/drupal/route.ts
@@ -244,7 +244,7 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
         title: data.route.entity.title,
       };
 
-      if (!Array.isArray(data.route.breadcrumbs) || data.route.breadcrumbs.length === 0) {
+      if (!Array.isArray(data.route.breadcrumbs)) {
         return [ currentPage ];
       }
 
@@ -256,16 +256,18 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
         return breadcrumb.url !== "/";
       });
 
-      // Remove last breadcrumb item if same as current page without URL
-      const lastBreadcrumbItem = breadcrumbPath[breadcrumbPath.length - 1];
-      if((currentPage.title === lastBreadcrumbItem?.title) && (lastBreadcrumbItem?.url === '')){
-        if(breadcrumbPath.length > 1){
-          // pop returns undefined if only one item
-          breadcrumbPath.pop(); 
-        }else{
-          breadcrumbPath = [];
-        }
-      }      
+      // Remove last breadcrumb item if same as current page
+      if(breadcrumbPath.length > 0){
+        const lastBreadcrumbItem = breadcrumbPath[breadcrumbPath.length - 1];
+        if((currentPage.title === lastBreadcrumbItem?.title) && (lastBreadcrumbItem?.url === '')){
+          if(breadcrumbPath.length > 1){
+            // pop returns undefined if only one item
+            breadcrumbPath.pop(); 
+          }else{
+            breadcrumbPath = [];
+          }
+        } 
+      }
       
       // Handle Basic Pages with Primary Navigation Homepage URL
       if(data.route.entity.__typename === "NodePage" && data.route.entity.primaryNavigation?.primaryNavigationUrl) {
@@ -274,8 +276,14 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
           url: data.route.entity.primaryNavigation?.primaryNavigationUrl?.url,
         };
 
-        // Only add Primary Nav Homepage URL if not already in breadcrumbPath
+        // Only add Primary Nav Homepage URL if not already at start of breadcrumbPath
         if (primaryNavigationHome && (breadcrumbPath[0]?.url !== primaryNavigationHome.url)){
+          
+          // Avoid duplicates if currentPage and primaryNavigation are the same
+          if(primaryNavigationHome.title === currentPage.title && breadcrumbPath.length === 0){
+            return [ primaryNavigationHome ];
+          }
+
           // Pages in multiple menus could have a breadcrumb path that does not belong to Primary Navigation
           // In this case, return only the breadcrumbHome and the currentPage
           if(data.route.entity.primaryNavigation?.menuName !== primary_navigation){  

--- a/data/drupal/route.ts
+++ b/data/drupal/route.ts
@@ -258,7 +258,7 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
 
       // Remove last breadcrumb item if same as current page without URL
       const lastBreadcrumbItem = breadcrumbPath[breadcrumbPath.length - 1];
-      if((currentPage.title === lastBreadcrumbItem.title) && (lastBreadcrumbItem.url === '')){
+      if((currentPage.title === lastBreadcrumbItem?.title) && (lastBreadcrumbItem?.url === '')){
         if(breadcrumbPath.length > 1){
           // pop returns undefined if only one item
           breadcrumbPath.pop(); 


### PR DESCRIPTION
# Summary of changes
- Use menu and primaryNavigationURL for breadcrumb route
- Fixes #191 

## Frontend
Use menu and primaryNavigationURL for breadcrumb route

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
- Add Menu Breadcrumbs module
- Add PrimaryNavigationURL to use as homepage stem (after home icon) in breadcrumb route

# Test Plan
Check a variety of pages with breadcrumbs issues, including:
1. 