### PR TITLE
Update Macleans ranking year from 2024 to 2025

### DIFF
--- a/components/client/home/rankings.js
+++ b/components/client/home/rankings.js
@@ -38,7 +38,7 @@ export const Rankings = () => {
             className={linkClasses}
             href="https://education.macleans.ca/feature/canadas-best-comprehensive-universities-rankings-2024/"
           >
-            Macleans, 2024
+            Macleans, 2025
           </a>
         </StatisticsItemRepresents>
       </StatisticsItem>


### PR DESCRIPTION
fp616256

# Summary of changes
FP#616256 Request from Linda to Update Macleans ranking year from 2024 to 2025

## Frontend
Changed the year for Macleans from 2024 t0 2025

- [ x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x ] My changes are responsive and appear as expected on mobile and desktop views.
- [x ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
No change.

# Test Plan

Insert steps. Include URLs of Netlify test site and Drupal multidev.