### PR TITLE
Homepage Statistics Link Update

### DIFF
--- a/components/client/home/rankings.js
+++ b/components/client/home/rankings.js
@@ -35,9 +35,9 @@ export const Rankings = () => {
         <StatisticsItemRepresents>
           <Link
             className={linkClasses}
-            href="https://education.macleans.ca/feature/canadas-best-comprehensive-universities-rankings-2024/"
+            href="https://news.uoguelph.ca/2025/11/u-of-g-among-canadas-top-comprehensive-universities-macleans-rankings/"
           >
-            Macleans, 2024
+            Macleans, 2026
           </Link>
         </StatisticsItemRepresents>
       </StatisticsItem>


### PR DESCRIPTION
# Summary of changes
Got a request to update some text and link for the "Rankings" section on the homepage

## Frontend
- Update Macleans rankings link and year in `rankings.js`

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

## Backend
N/A

# Test Plan

Go to https://deploy-preview-235--ugnext.netlify.app/ and ensure link and year is updated for the second stat in the "Our Rankings" section