### PR TITLE
Add redirects for Drupal file paths using `NEXT_PUBLIC_DRUPAL_BASE_URL`

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,10 @@
 import type { NextConfig } from "next";
 
+const DRUPAL_BASE_URL = (process.env.NEXT_PUBLIC_DRUPAL_BASE_URL ?? "https://api.liveugconthub.uoguelph.dev").replace(
+  /\/+(?=\?|#|$)/g,
+  ""
+);
+
 const nextConfig: NextConfig = {
   output: process.env.NEXT_STATIC_OUTPUT === "true" ? "export" : undefined,
   reactStrictMode: true,
@@ -8,7 +13,7 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: new URL(process.env.NEXT_PUBLIC_DRUPAL_BASE_URL as string).hostname,
+        hostname: new URL(DRUPAL_BASE_URL).hostname,
         port: "",
         pathname: "/sites/default/files/**",
       },
@@ -36,7 +41,7 @@ const nextConfig: NextConfig = {
       },
       {
         source: "/sites/default/files/:path*",
-        destination: `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL as string}/sites/default/files/:path*`,
+        destination: `${DRUPAL_BASE_URL}/sites/default/files/:path*`,
         permanent: false,
       },
     ];


### PR DESCRIPTION
# Summary of changes
Fixes https://github.com/ccswbs/ugnext/issues/217

## Frontend
- Added redirect for "/sites/default/files/*" in next.config.ts
- Updated next.config.ts to handle trailing slashes in NEXT_PUBLIC_DRUPAL_BASE_URL

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to [/widget-examples](https://deploy-preview-239--ugnext.netlify.app/widget-examples#links).
2. Click the link labeled "Test PDF (Absolute URL)", it should correctly go to the file now. 