### PR TITLE
Refactor to not call MediaCaption if caption data doesn't exist

### DIFF
--- a/components/client/widgets/media-text.tsx
+++ b/components/client/widgets/media-text.tsx
@@ -92,20 +92,54 @@ export function MediaTextWidget({ data }: { data: MediaTextFragment }) {
     },
   })({ background: background });
 
+  // Early return if no media
+  if (!media) {
+    return null;
+  }
+
+  // Determine if we have any content to show
+  const hasContent = !!(data.heading || data.description?.processed || data.buttonSection);
+
+  // If no content, render just the media element directly
+  if (!hasContent) {
+    const MediaComponent = media.__typename === "image" ? Image : EmbeddedVideo;
+    
+    // For small images with no content, render at original dimensions with no classes
+    const isSmallImage = media.__typename === "image" && size === "small";
+    
+    const mediaProps = {
+      id: `media-and-text-${data.uuid}`,
+      src: media.src,
+      height: media?.height,
+      width: media?.width,
+      alt: data.mediaIsDecorative ? "" : (media?.alt ?? ""),
+      ...(isSmallImage ? {} : { className: twMerge("w-full object-cover", classes.base()) }),
+      ...(media.__typename === "video" && { 
+        title: media.title,
+        transcript: media?.transcript?.url 
+      }),
+    };
+
+    return <MediaComponent {...mediaProps} />;
+  }
+
+  // Otherwise, render the full MediaCaption layout
+  const mediaCaptionProps = {
+    id: `media-and-text-${data.uuid}`,
+    src: media.src,
+    height: media?.height,
+    width: media?.width,
+    alt: data.mediaIsDecorative ? "" : (media?.alt ?? ""),
+    as: media.__typename === "image" ? Image : EmbeddedVideo,
+    background,
+    size,
+    position,
+    className: twMerge(classes.base(), data.description ? null : classes.no_body()),
+    transcript: media?.transcript?.url,
+  } as const;
+
   return (
-    <MediaCaption
-      id={`media-and-text-${data.uuid}`}
-      src={media.src}
-      height={media?.height}
-      width={media?.width}
-      alt={data.mediaIsDecorative ? "" : (media?.alt ?? "")}
-      as={media.__typename === "image" ? Image : EmbeddedVideo}
-      background={background}
-      size={size}
-      position={position}
-      className={twMerge(classes.base(), data.description ? null : classes.no_body())}
-      transcript={media?.transcript?.url}
-    >
+    <MediaCaption {...mediaCaptionProps}>
       {data.heading && (
         <Typography
           id={`media-and-text-heading-${data.uuid}`}


### PR DESCRIPTION
# Summary of changes
- Fixes #198 

## Frontend
- Refactor `media-text.tsx` to render image or video directly when no caption content exists (prevents empty caption div)
- Add logic to strip all classes from images when their size is set to small and they have no caption content

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to https://deploy-preview-243--ugnext.netlify.app/media-and-text-examples and:
    - Verify items with descriptions display as expected
    - Verify the videos with no description, buttons, or other caption content display without an empty div underneath (as they do on https://ugnext.netlify.app/media-and-text-examples)
- Go to https://deploy-preview-243--ugnext.netlify.app/media-edge-cases and verify the first image (which is set to Small) displays at its original size (as opposed to full width). 
- Go to https://deploy-preview-243--ugnext.netlify.app/cbs/about-cbs/strategic-plan and verify the image near the bottom remains full width.