### PR TITLE
Fix row parser logic

### DIFF
--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -545,7 +545,7 @@ const defaultInstructions: ParserInstruction[] = [
   },
   // Rows and Columns
   {
-    shouldProcessNode: (node, props) => (props.className as string)?.includes("row"),
+    shouldProcessNode: (node, props) => /\brow\b/.test(props.className as string),
     processNode: (node, props, children, index) => {
       interface TemplateValues {
         [key: string]: string[] | undefined;
@@ -559,6 +559,8 @@ const defaultInstructions: ParserInstruction[] = [
 
       let convertedGrid: string[] = [];
 
+      console.log(node);
+
       {
         React.Children.map(children, (child) => {
           // Parse divs with Boostrap column classes
@@ -568,7 +570,7 @@ const defaultInstructions: ParserInstruction[] = [
             // console.log("Converting:" + bsClasses);
 
             // Assumes Bootstrap format can be col, col-6, col-md, or col-md-6
-            if (bsClasses.includes("col")) {
+            if (bsClasses?.includes("col")) {
               let bsColumnClasses: string[] = bsClasses.split(" ");
 
               bsColumnClasses.forEach((columnClass) => {

--- a/components/client/html-parser.tsx
+++ b/components/client/html-parser.tsx
@@ -559,8 +559,6 @@ const defaultInstructions: ParserInstruction[] = [
 
       let convertedGrid: string[] = [];
 
-      console.log(node);
-
       {
         React.Children.map(children, (child) => {
           // Parse divs with Boostrap column classes


### PR DESCRIPTION
# Summary of changes
Fixes #250

## Frontend
- Add null check for bsClasses
- Only parse divs with the specific class `row` instead of `something-row` or `row-something`

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Check https://deploy-preview-251--ugnext.netlify.app/housing/why-live-residence