### PR TITLE
Fix breadcrumbs for pages not in menu (again)

### DIFF
--- a/data/drupal/menu.ts
+++ b/data/drupal/menu.ts
@@ -21,6 +21,35 @@ export const MENU_FRAGMENT = gql(/* gql */ `
   }
 `);
 
+export async function getMenuLinkByURI(link_uri: string, menu_name: string) {
+  const { data, error } = await query({
+    query: gql(/* gql */ `
+      query MenuLinkByURI($link_uri: String!, $menu_name: String!) {
+        menuLinkContent(filter: {link__uri: $link_uri, menu_name: $menu_name}) {
+          results {
+            id
+          }
+        }
+      }
+    `),
+    variables: {
+      // @ts-ignore
+      link_uri: link_uri,
+      menu_name: menu_name,
+    },
+  });
+
+  if (error) {
+    handleGraphQLError(error);
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return data.menuLinkContent?.results;
+}
+
 export async function getMenuByName(name: string) {
   if (name === "NO_MENU") {
     return null;

--- a/data/drupal/route.ts
+++ b/data/drupal/route.ts
@@ -1,7 +1,9 @@
 import { getClient, handleGraphQLError } from "@/lib/apollo";
 import { gql } from "@/lib/graphql";
 import { showUnpublishedContent } from "@/lib/show-unpublished-content";
-import { RouteQuery, RouteBreadcrumbsQuery } from "@/lib/graphql/types";
+import { RouteQuery, RouteBreadcrumbsQuery, NodePage } from "@/lib/graphql/types";
+import { getMenuLinkByURI } from "@/data/drupal/menu";
+import { Link, RouteEntityUnion } from "@/lib/graphql/graphql";
 
 export type Route = NonNullable<RouteQuery["route"]>;
 
@@ -164,6 +166,49 @@ export async function getRoute(url: string) {
   }
 }
 
+export async function checkIsEntityInMenu (entity_id: string, entity_path: string | null | undefined, primary_navigation: string | undefined) {
+  if(primary_navigation){
+    const entityNodeURL = entity_id ? `node/${entity_id}` : null;
+    const checkMenuForEntityID = entityNodeURL ? await getMenuLinkByURI(entityNodeURL, primary_navigation) : null;
+
+    // Check both node URL and path URL
+    if(!checkMenuForEntityID || checkMenuForEntityID?.length === 0){
+      const checkMenuForEntityPath = entity_path ? await getMenuLinkByURI(entity_path, primary_navigation) : null;
+      if(!checkMenuForEntityPath || checkMenuForEntityPath?.length === 0){
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+function filterBreadcrumbs (breadcrumbs: Link[], currentPage: {title: string}) {
+  // Filter out elements without titles and the root from Breadcrumb Path
+  let breadcrumbPath = breadcrumbs.filter((breadcrumb) => {
+    if (!breadcrumb.title) {
+      return false;
+    }
+    return breadcrumb.url !== "/";
+  });
+
+  // Remove last breadcrumb item if same as current page
+  if(breadcrumbPath.length > 0){
+    const lastBreadcrumbItem = breadcrumbPath[breadcrumbPath.length - 1];
+    if((currentPage.title === lastBreadcrumbItem?.title) && (lastBreadcrumbItem?.url === '')){
+      if(breadcrumbPath.length > 1){
+        // pop returns undefined if only one item
+        breadcrumbPath.pop(); 
+      }else{
+        breadcrumbPath = [];
+      }
+    } 
+  }
+
+  return breadcrumbPath;
+}
+
+
+// Route assumes we are using Menu-generated Breadcrumbs instead of Path-based Breadcrumbs
 export async function getRouteBreadcrumbs(url: string, primary_navigation: string | undefined) {
   const client = getClient();
   const breadcrumbsQuery = gql(/* gql */ `
@@ -175,6 +220,7 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
             __typename
             title
             url
+            internal
           }
           entity {
             ... on NodeArticle {
@@ -199,6 +245,8 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
               title
             }
             ... on NodePage {
+              id
+              path
               title
               primaryNavigation {
                 menuName
@@ -218,9 +266,6 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
               title
             }
             ... on NodeTestimonial {
-              title
-            }
-            ... on NodeUserDocumentation {
               title
             }
           }
@@ -259,44 +304,36 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
         return [ currentPage ];
       }
 
-      // Filter out elements without titles and the root from Breadcrumb Path
-      let breadcrumbPath = data.route.breadcrumbs.filter((breadcrumb) => {
-        if (!breadcrumb.title) {
-          return false;
-        }
-        return breadcrumb.url !== "/";
-      });
+      let breadcrumbPath = filterBreadcrumbs(data.route.breadcrumbs, currentPage);
 
-      // Remove last breadcrumb item if same as current page
-      if(breadcrumbPath.length > 0){
-        const lastBreadcrumbItem = breadcrumbPath[breadcrumbPath.length - 1];
-        if((currentPage.title === lastBreadcrumbItem?.title) && (lastBreadcrumbItem?.url === '')){
-          if(breadcrumbPath.length > 1){
-            // pop returns undefined if only one item
-            breadcrumbPath.pop(); 
-          }else{
-            breadcrumbPath = [];
-          }
-        } 
-      }
-      
-      // Handle Basic Pages with Primary Navigation Homepage URL
+      /* ---- Handle Basic Pages with Primary Navigation Homepage URL --- */
       if(data.route.entity.__typename === "NodePage" && data.route.entity.primaryNavigation?.primaryNavigationUrl) {
         const primaryNavigationHome = {
           title: data.route.entity.primaryNavigation?.primaryNavigationUrl?.title,
           url: data.route.entity.primaryNavigation?.primaryNavigationUrl?.url,
         };
 
-        // Only add Primary Nav Homepage URL if not already at start of breadcrumbPath
+        /* ---- Handle pages that are NOT in the menu --- */
+        // If page NOT in menu, return [Primary Nav Home > currentPage]
+        const isPageInMenu = await checkIsEntityInMenu(data.route.entity.id, data.route.entity.path, primary_navigation); 
+        if(!isPageInMenu){
+          return [
+            primaryNavigationHome,
+            currentPage,
+          ];
+        }
+
+        // Only add Primary Nav Homepage URL if NOT already at start of breadcrumbPath
         if (primaryNavigationHome && (breadcrumbPath[0]?.url !== primaryNavigationHome.url)){
           
-          // Avoid duplicates if currentPage and primaryNavigation are the same
+          // If Primary Nav Home and currentPage are SAME, only return [ Primary Nav Home ]
           if(primaryNavigationHome.title === currentPage.title && breadcrumbPath.length === 0){
             return [ primaryNavigationHome ];
           }
 
-          // Pages in multiple menus could have a breadcrumb path that does not belong to Primary Navigation
-          // In this case, return only the breadcrumbHome and the currentPage
+          /* ---- Handle pages in MULTIPLE MENUS --- */
+          // Pages in multiple menus can have breadcrumb path from a different menu than Primary Navigation
+          // If page in multiple menus, return [Primary Nav Home > currentPage]
           if(data.route.entity.primaryNavigation?.menuName !== primary_navigation){  
             return [
               primaryNavigationHome,
@@ -304,6 +341,7 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
             ];
           }
 
+          // Default return
           return [
             primaryNavigationHome,
             ...breadcrumbPath,


### PR DESCRIPTION
# Summary of changes
Fixes #229
(Second time fix - this time the back-end has been fixed. Code is the same)

## Frontend
Same as previous PR #244 

## Backend
Instead of using Menu Items Extra (which changes the structure of menus and deletes the jsonapi endpoint of menu_link_content/menu_link_content), we are now using Menu Entity Index which:
- does NOT change the structure of menus 
- does NOT delete the jsonapi component)
- is available via GraphQL views

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Check https://deploy-preview-254--ugnext.netlify.app/oac/fare/research/published to confirm if breadcrumbs are only showing Primary Navigation Home > Current Page title (instead of [Primary Navigation Home > Path-generated breadcrumbs > Current Page title])
1. Check other pages to confirm all is working as expected, particularly anything already in production