### PR TITLE
Added Accordion Description - Gap analysis Fix

### DIFF
--- a/components/client/widgets/accordions.tsx
+++ b/components/client/widgets/accordions.tsx
@@ -7,6 +7,7 @@ import type { AccordionFragment } from "@/lib/graphql/types";
 export function AccordionWidget({ data }: { data: AccordionFragment }) {
   const level = data.headingLevel ? (getHeadingLevel(data.headingLevel) ?? 3) : 2;
   const sectionTitle = data?.accordionSectionTitle;
+  const sectionDescription = data?.accordionDescription?.processed;
 
   return (
     <>
@@ -15,6 +16,7 @@ export function AccordionWidget({ data }: { data: AccordionFragment }) {
           {sectionTitle}
         </Typography>
       )}
+      {sectionDescription && <HtmlParser html={sectionDescription} />}
 
       {data?.items.map((item, index) => (
         <Accordion id={`accordion-${item.uuid}`} key={index}>

--- a/data/drupal/widgets.ts
+++ b/data/drupal/widgets.ts
@@ -30,6 +30,9 @@ export const ACCORDION_FRAGMENT = gql(/* gql */ `
     id
     headingLevel
     accordionSectionTitle: title
+    accordionDescription {
+      processed
+    }
     items {
       ... on ParagraphAccordionBlock {
         uuid


### PR DESCRIPTION
# Summary of changes
Gap analysis Fixes https://github.com/ccswbs/ugnext/issues/253
Added Accordion Description field to the accordions.tsx component as well as widgets.ts

## Frontend

- Added accordionDescription field to the accordions.tsx
- Added accordionDescription field to the widgets.ts

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Check https://deploy-preview-259--ugnext.netlify.app/formatting-test to confirm if Accordion Description is showing under the Accordion Title widget.
- Check other pages to confirm all is working as expected.
- An example page using the accordion description field in gus is https://api.liveugconthub.uoguelph.dev/formatting-test