### PR TITLE
Disable app armor when the USE_TESTING_DATA is true

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -57,7 +57,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 
         <Script src="https://kit.fontawesome.com/7993323d0c.js" crossOrigin="anonymous" strategy="lazyOnload" />
 
-        <AppArmor />
+        {process.env.USE_TESTING_DATA !== "true" && <AppArmor />}
 
         {isDraftMode && (
           <div className="sticky left-0 top-0 z-20 flex h-fit w-full items-center justify-center gap-2 bg-red p-2 text-center text-base font-bold text-white">


### PR DESCRIPTION
Fixes https://github.com/ccswbs/ugnext/issues/238

# Summary of changes
When an alert is active, the playwright visual regression test on the homepage will fail, which makes sense as the modal opens on load affecting the final screenshot playwright generates significantly.

Potential Solution: Disable app armor alerts in ugnext when running a playwright build (via USE_TESTING_DATA env variable).

## Frontend
Check app/layout.tsx -> added conditional based on whether the environment var USE_TESTING_DATA is set to "true"

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

When an alert is active, confirm AppArmor is skipped.