### PR TITLE
Story Widget - Update blue quote to yellow

### DIFF
--- a/components/client/widgets/story.tsx
+++ b/components/client/widgets/story.tsx
@@ -83,7 +83,7 @@ function StoryImageCutoutBackground({ data }: { data: StoryImageCutoutBackground
           {quotes.map((quote) => {
             return (
               <div className="flex flex-col justify-center items-center gap-4" key={quote.id}>
-                <Blockquote color="blue" className="font-thin text-3xl tracking-wider">
+                <Blockquote color="yellow" className="font-thin text-3xl tracking-wider">
                   <BlockquoteContent>{quote.quoteContent}</BlockquoteContent>
                 </Blockquote>
                 <BlockquoteAuthor className="text-light-blue">


### PR DESCRIPTION
## Frontend

Updated Blockquote color="blue" to Blockquote color="yellow" as a fix to issue 133 https://github.com/ccswbs/ugnext/issues/133

## Backend
N/A
## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

Go to /widget-examples page to review the story widget quote color in yellow