### PR TITLE
Make Links as list use Next.js Link component

### DIFF
--- a/components/client/widgets/links.tsx
+++ b/components/client/widgets/links.tsx
@@ -125,7 +125,9 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
 
             return (
               <ListItem key={url + index}>
-                <Link href={url}>{title}</Link>
+                <Link as={NextLink} href={url}>
+                  {title}
+                </Link>
               </ListItem>
             );
           })}


### PR DESCRIPTION
# Summary of changes
Update the Links widget to use Next.js' Link component when displayed as List

## Frontend
- Set as component on Link in components/client/widgets/links.tsx

## Backend
N/A

## Checklist

- [ ] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [ ] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-326--ugnext.netlify.app/miranda-testing-clone-research-participants-needed ensure links point to https://api.liveugconthub.uoguelph.dev instead of https://deploy-preview-326--ugnext.netlify.app (note its a redirect so you will need to test by clicking the link)