### PR TITLE
Add 'items-stretch' class to Media Grid layout

### DIFF
--- a/components/client/widgets/section-widget.tsx
+++ b/components/client/widgets/section-widget.tsx
@@ -153,7 +153,7 @@ export function SectionWidget({ data }: SectionWidgetProps) {
               // Handle Media Grid Layout
               if (widget[0].__typename === "ParagraphMediaText") {
                 return (
-                  <Grid key={index} className="gap-4" template={renderMediaGrid(widget, sectionClasses)}>
+                  <Grid key={index} className="gap-4 items-stretch" template={renderMediaGrid(widget, sectionClasses)}>
                     {widget.map((w, i) => (
                       <WidgetSelector data={w as Widgets} key={i} />
                     ))}


### PR DESCRIPTION
# Summary of changes
Make the height equal for media widget items

Fixes #309

## Frontend
Added "items-stretch" to section-widget.tsx

## Backend
n/a

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to https://deploy-preview-342--ugnext.netlify.app/research/about
- Check that the grey boxes have the same height at various widths