### PR TITLE
Fix alt text issue on linked news cards and only render FeaturedNews widget if articles exist

### DIFF
--- a/components/client/news/news-card.tsx
+++ b/components/client/news/news-card.tsx
@@ -85,7 +85,7 @@ export function NewsCard({
       <div className={imageContainer()}>
         <Image
           src={img?.url ?? defaultImage.src}
-          alt={alt ?? ""}
+          alt=""
           width={`${img?.width ?? 800}`}
           height={`${img?.height ?? 450}`}
           className={image()}

--- a/components/client/widgets/featured-news.tsx
+++ b/components/client/widgets/featured-news.tsx
@@ -104,7 +104,7 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
 
   let variant: "spotlight" | "grid" | "single-column" | "list" = "grid";
 
-  if (!Array.isArray(data.articles)) {
+  if (!Array.isArray(data.articles) || (data.articles.length === 0)) {
     return null;
   }
 


### PR DESCRIPTION
# Summary of changes
- Ensure linked news cards read content rather than alt text
   - Fixes #358 
   - Fixes #364
- Only render FeaturedNews widget if articles exist
   - Fixed #362

## Frontend
- Ensure linked news cards read content rather than alt text

## Backend
- None

## Checklist
- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan
1. Run the changes locally
2. View a page with the FeaturedNews widget that has no news and confirm the Featured News widget does not render (e.g., http://localhost:3000/ccmps/unit-news-listing-page-miranda)
3. Confirm the linked news cards on /news do not read the alt text, but just the link destination