### PR TITLE
News Breadcrumbs - only render unit news home + directory if values exist / only show news default values for no-menu setting

### DIFF
--- a/components/server/news.tsx
+++ b/components/server/news.tsx
@@ -24,13 +24,22 @@ import { customRandom } from "nanoid";
 function NewsBreadcrumbs({ article }: { article: FullNewsArticle }) {
   return (
     <Breadcrumbs>
-      <BreadcrumbHome href={article.home.url} title={article.home.title} />
+      <BreadcrumbHome href="/" />
+      {article.unitHome.title && 
+        <Breadcrumb href={article.unitHome.url} as={Link}>
+          {article.unitHome.title}
+        </Breadcrumb>}
+        
+      {article.newsHome.title && 
+        <Breadcrumb href={article.newsHome.url} as={Link}>
+          {article.newsHome.title}
+        </Breadcrumb>}
 
-      <Breadcrumb href={article.directory.url} as={Link}>
-        {article.directory.title}
-      </Breadcrumb>
+      {article.directory.title && 
+        <Breadcrumb href={article.directory.url} as={Link}>
+          {article.directory.title}
+        </Breadcrumb>}
 
-      <Breadcrumb as="span">{article.title}</Breadcrumb>
     </Breadcrumbs>
   );
 }

--- a/data/drupal/news.ts
+++ b/data/drupal/news.ts
@@ -112,6 +112,10 @@ export function getNewsBreadcrumb(article: NewsFragment) {
   }
 
   if (article.primaryNavigation.menuName === "no-menu") {
+    values.unitHome.url = "/news";
+    values.unitHome.title = "News";
+    values.directory.url = "/news/directory";
+    values.directory.title = "News Directory";
     return values;
   }
 

--- a/data/drupal/news.ts
+++ b/data/drupal/news.ts
@@ -91,15 +91,19 @@ export const NEWS_FRAGMENT = gql(/* gql */ `
   }
 `);
 
-export function getNewsHomeAndDirectory(article: NewsFragment) {
+export function getNewsBreadcrumb(article: NewsFragment) {
   const values = {
-    home: {
-      url: "/news",
-      title: "News",
+    unitHome: {
+      url: "",
+      title: "",
+    },
+    newsHome: {
+      url: "",
+      title: "",
     },
     directory: {
-      url: "/news/directory",
-      title: "News Directory",
+      url: "",
+      title: "",
     },
   };
 
@@ -111,9 +115,15 @@ export function getNewsHomeAndDirectory(article: NewsFragment) {
     return values;
   }
 
+  // Get primary Navigation homepage
+  if (article.primaryNavigation.homePage?.url) {
+    values.unitHome.url = article.primaryNavigation.homePage.url;
+    values.unitHome.title = article.primaryNavigation.homePage.title ?? "";
+  }
+
   if (article.primaryNavigation.newsHomePage?.url) {
-    values.home.url = article.primaryNavigation.newsHomePage.url;
-    values.home.title = article.primaryNavigation.newsHomePage.title ?? `${article.primaryNavigation.name} News`;
+    values.newsHome.url = article.primaryNavigation.newsHomePage.url;
+    values.newsHome.title = article.primaryNavigation.newsHomePage.title ?? `${article.primaryNavigation.name} News`;
   }
 
   if (article.primaryNavigation.newsDirectoryPage?.url) {
@@ -126,7 +136,11 @@ export function getNewsHomeAndDirectory(article: NewsFragment) {
 }
 
 export type FullNewsArticle = Omit<NewsFragment, "widgets"> & {
-  home: {
+  unitHome: {
+    url: string;
+    title: string;
+  };
+  newsHome: {
     url: string;
     title: string;
   };
@@ -168,12 +182,13 @@ export async function getNewsArticle(id: string) {
     return null;
   }
 
-  const { home, directory } = getNewsHomeAndDirectory(data.nodeNews);
+  const { unitHome, newsHome, directory } = getNewsBreadcrumb(data.nodeNews);
   const processor = new WidgetProcessor();
 
   return {
     ...(data.nodeNews as NewsFragment),
-    home: home,
+    unitHome: unitHome,
+    newsHome: newsHome,
     directory: directory,
     widgets: await processor.processWidgets(data.nodeNews.widgets ?? []),
   } as FullNewsArticle;


### PR DESCRIPTION
# Summary of changes
Update news breadcrumbs
Fix #357
Fix #368

## Frontend
- Only render news home + directory if values exist
- Remove news title from breadcrumbs (this was requested for pages as well in the issue queue)
- Add the primaryNavigation homepage to the top of the breadcrumb
- Only set default values to /news and /news/directory for news home and news directory if primary navigation is set to no-menu. (Note: we could also choose to completely tie those values to a specific primary navigation for central news)

## Backend
- None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Test locally
2. Review news breadcrumbs on /ccmps/news/2026/09/created-news-draft-author-ready-review
3. Review news breadcrumbs on /news/2026/06/cats-could-hold-new-keys-human-cancer