### PR TITLE
Fix title off on the side so it appears within the container

### DIFF
--- a/components/client/widgets/featured-news.tsx
+++ b/components/client/widgets/featured-news.tsx
@@ -131,9 +131,11 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
   return (
     <div>
       {data.title && (
-        <Typography type="h3" as="h3">
-          {data.title}
-        </Typography>
+        <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0">
+          <Typography type="h3" as="h3">
+            {data.title}
+          </Typography>
+        </Container>
       )}
 
       {variant === "spotlight" ? (
@@ -149,7 +151,7 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
       <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0">
         <Link href={directory} className="w-full md:w-fit mt-4">
           {Array.isArray(data.categories) && data.categories.length === 1
-            ? `More ${data.categories[0].name}`
+            ? `More ${data.categories[0].name} News`
             : `More News`}
         </Link>
       </Container>

--- a/components/client/widgets/featured-news.tsx
+++ b/components/client/widgets/featured-news.tsx
@@ -151,7 +151,7 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
       <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0">
         <Link href={directory} className="w-full md:w-fit mt-4">
           {Array.isArray(data.categories) && data.categories.length === 1
-            ? `More ${data.categories[0].name} News`
+            ? `More ${data.categories[0].name}`
             : `More News`}
         </Link>
       </Container>


### PR DESCRIPTION
# Summary of changes
Fix #359 

Before
<img width="1626" height="798" alt="image" src="https://github.com/user-attachments/assets/50095cb0-6997-49d6-ac57-b2dec8f39478" />

After
<img width="1713" height="816" alt="image" src="https://github.com/user-attachments/assets/c4f0887c-cf5d-47d2-8d8e-3d0dddc954b0" />


## Frontend
- Fix title off on the side so it appears within the container

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Check locally
2. Check /news and /ccmps/news