### PR TITLE
Fix colour contrast of paginated grid summary

### DIFF
--- a/components/client/paginated-grid.tsx
+++ b/components/client/paginated-grid.tsx
@@ -129,7 +129,7 @@ export function PaginatedGrid<T>({ url, render, debounce = 300 }: PaginatedGridP
         />
       )}
 
-      <div className="mb-4 text-center text-sm opacity-70">
+      <div className="mb-4 text-center text-sm text-body-copy">
         Showing {data.results.length} of {data.total} results
       </div>
 


### PR DESCRIPTION
# Summary of changes
Fix #374 

## Frontend
Fix colour contrast of paginated grid summary

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Check colour contrast (Accessibility Insights) of /ovc/news
1. Check colour contrast (Accessibility Insights) of /csahs/people