### PR TITLE
Sitemap Generation

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { getAllBasicPagePaths } from "@/data/drupal/basic-page";
+import { getAllProfilePaths } from "@/data/drupal/profile";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const basicPages = await getAllBasicPagePaths();
+  const profiles = await getAllProfilePaths();
+  const paths = [
+    ...profiles.map((path) => ({ url: `https://uoguelph.ca${path}` })),
+    ...basicPages.map((path) => ({ url: `https://uoguelph.ca${path}` })),
+  ];
+
+  if (paths.length > 50000) {
+    throw new Error(
+      "Google has a limit of 50,000 URLs per sitemap. See https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generating-multiple-sitemaps for more information on splitting sitemap."
+    );
+  }
+
+  return paths;
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,14 +1,16 @@
 import type { MetadataRoute } from "next";
 import { getAllBasicPagePaths } from "@/data/drupal/basic-page";
 import { getAllProfilePaths } from "@/data/drupal/profile";
+import { getAllLegacyNewsArticlePaths } from "@/data/drupal/ovc-news";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const mappingFunc = (path: string) => ({ url: `https://www.uoguelph.ca${path}` });
+
   const basicPages = await getAllBasicPagePaths();
   const profiles = await getAllProfilePaths();
-  const paths = [
-    ...profiles.map((path) => ({ url: `https://uoguelph.ca${path}` })),
-    ...basicPages.map((path) => ({ url: `https://uoguelph.ca${path}` })),
-  ];
+  const legacyNews = await getAllLegacyNewsArticlePaths();
+
+  const paths = [...legacyNews.map(mappingFunc), ...profiles.map(mappingFunc), ...basicPages.map(mappingFunc)];
 
   if (paths.length > 50000) {
     throw new Error(

--- a/data/drupal/basic-page.ts
+++ b/data/drupal/basic-page.ts
@@ -2,6 +2,7 @@ import { gql } from "@/lib/graphql";
 import { showUnpublishedContent } from "@/lib/show-unpublished-content";
 import { getClient, handleGraphQLError, query } from "@/lib/apollo";
 import { getFullTestimonialSlider } from "@/data/drupal/widgets";
+import { cache } from "react";
 
 export const BASIC_PAGE_FRAGMENT = gql(/* gql */ `
   fragment BasicPage on NodePage {
@@ -90,7 +91,7 @@ export async function getPageContent(id: string) {
   };
 }
 
-export async function getAllBasicPagePaths() {
+async function getAllBasicPagePathsUncached() {
   const client = getClient();
 
   const pathQuery = gql(/* gql */ `
@@ -147,3 +148,4 @@ export async function getAllBasicPagePaths() {
 
   return paths;
 }
+export const getAllBasicPagePaths = cache(getAllBasicPagePathsUncached);

--- a/data/drupal/ovc-news.ts
+++ b/data/drupal/ovc-news.ts
@@ -2,6 +2,7 @@ import { gql } from "@/lib/graphql";
 import { getClient, handleGraphQLError } from "@/lib/apollo";
 import { NewsWithoutBodyFragment } from "@/lib/graphql/graphql";
 import { showUnpublishedContent } from "@/lib/show-unpublished-content";
+import { cache } from "react";
 
 export const NEWS_FRAGMENT = gql(/* gql */ `
   fragment News on NodeArticle {
@@ -196,3 +197,62 @@ export async function getFeaturedNewsArticles() {
 
   return data.featuredLegacyNews.results as NewsWithoutBodyFragment[];
 }
+
+async function getAllNewsArticlePathsUncached() {
+  const client = getClient();
+
+  const pathQuery = gql(/* gql */ `
+    query LegacyNewsIDs($cursor: Cursor) {
+      nodeArticles(after: $cursor, first: 100) {
+        nodes {
+          __typename
+          id
+          status
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `);
+
+  let cursor = "";
+  let hasNextPage = true;
+  const paths: string[] = [];
+
+  while (hasNextPage) {
+    const { data, error } = await client.query({
+      query: pathQuery,
+      variables: {
+        cursor,
+      },
+    });
+
+    if (error) {
+      handleGraphQLError(error);
+    }
+
+    if (!data) {
+      return paths;
+    }
+
+    if (!data.nodeArticles.nodes.length) {
+      return paths;
+    }
+
+    const currentPaths = data.nodeArticles.nodes
+      .filter((page) => page.status)
+      .map((page) => `/ovc/news/node/${page.id}`)
+      .filter((path) => typeof path === "string");
+
+    paths.push(...currentPaths);
+
+    cursor = data.nodeArticles.pageInfo.endCursor;
+    hasNextPage = data.nodeArticles.pageInfo.hasNextPage;
+  }
+
+  return paths;
+}
+
+export const getAllLegacyNewsArticlePaths = cache(getAllNewsArticlePathsUncached);

--- a/data/drupal/profile.ts
+++ b/data/drupal/profile.ts
@@ -3,6 +3,7 @@ import { showUnpublishedContent } from "@/lib/show-unpublished-content";
 import { getClient, handleGraphQLError } from "@/lib/apollo";
 import type { FullProfile } from "@/lib/types";
 import type { PartialProfileFragment, ProfileTypeFragment } from "@/lib/graphql/types";
+import { cache } from "react";
 
 // GraphQL Response Types
 interface PageInfo {
@@ -367,7 +368,7 @@ export type Unit = {
 export async function getAllUnits(): Promise<Unit[]> {
   try {
     const client = getClient();
-    
+
     const { data } = await client.query({
       query: gql(/* GraphQL */ `
         query GetAllUnits {
@@ -384,7 +385,7 @@ export async function getAllUnits(): Promise<Unit[]> {
 
     if ((data as any)?.termUnits?.edges) {
       const units = (data as any).termUnits.edges.map((edge: any) => edge.node) as Unit[];
-      
+
       // Sort units alphabetically by name
       return units.sort((a, b) => a.name.localeCompare(b.name));
     }
@@ -396,3 +397,63 @@ export async function getAllUnits(): Promise<Unit[]> {
     return [];
   }
 }
+
+async function getAllProfilePathsUncached() {
+  const client = getClient();
+
+  const pathQuery = gql(/* gql */ `
+    query ProfilePagePaths($cursor: Cursor) {
+      nodeProfiles(after: $cursor, first: 100) {
+        nodes {
+          __typename
+          id
+          status
+          path
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  `);
+
+  let cursor = "";
+  let hasNextPage = true;
+  const paths: string[] = [];
+
+  while (hasNextPage) {
+    const { data, error } = await client.query({
+      query: pathQuery,
+      variables: {
+        cursor,
+      },
+    });
+
+    if (error) {
+      handleGraphQLError(error);
+    }
+
+    if (!data) {
+      return paths;
+    }
+
+    if (!data.nodeProfiles.nodes.length) {
+      return paths;
+    }
+
+    const currentPaths = data.nodeProfiles.nodes
+      .filter((page) => page.status)
+      .map((page) => page.path)
+      .filter((path) => typeof path === "string");
+
+    paths.push(...currentPaths);
+
+    cursor = data.nodeProfiles.pageInfo.endCursor;
+    hasNextPage = data.nodeProfiles.pageInfo.hasNextPage;
+  }
+
+  return paths;
+}
+
+export const getAllProfilePaths = cache(getAllProfilePathsUncached);

--- a/next.config.ts
+++ b/next.config.ts
@@ -54,6 +54,14 @@ const nextConfig: NextConfig = {
       },
     ];
   },
+  async rewrites() {
+    return [
+      {
+        source: "/sitemap-next.xml",
+        destination: "/sitemap.xml",
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# Summary of changes
Using Next.js sitemap generation to create a sitemap that covers basic pages and profile pages.

See more info here: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap

## Frontend
- Added app/sitemap.ts
- Updated getAllBasicPagePaths function in data/drupal/basic-page.ts to be a react cached function
- Created getAllProfilePaths function in data/drupal/profile.ts with similar functionality to getAllBasicPagePaths but for profiles

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-376--ugnext.netlify.app/sitemap.xml, use view page source in Chrome or Firefox to see raw XML output, ensure sitemap looks valid