### PR TITLE
Make buttons w-full in secondary region

### DIFF
--- a/components/client/widgets/button.tsx
+++ b/components/client/widgets/button.tsx
@@ -65,7 +65,7 @@ export const ButtonWidget = ({ data, column }: { data: ButtonsFragment; column: 
   const classes = tv({
     slots: {
       heading: "block text-black basis-full group-first/button:first:mt-0",
-      button: "w-full md:w-fit font-medium flex items-center justify-center! gap-x-1 leading-6 mx-0",
+      button: "w-full md:w-fit font-medium flex items-center justify-start! gap-x-1 leading-6 mx-0",
       icon: ["pe-3 text-4xl inline-block align-middle", icon.data],
     },
     variants: {

--- a/components/client/widgets/button.tsx
+++ b/components/client/widgets/button.tsx
@@ -72,7 +72,7 @@ export const ButtonWidget = ({ data, column }: { data: ButtonsFragment; column: 
       column: {
         primary: {},
         secondary: {
-          button: "w-full mx-0",
+          button: "w-full md:w-full mx-0",
         },
         "call-to-action": {},
       },


### PR DESCRIPTION
# Summary of changes
Fix #360

Before:
<img width="1501" height="527" alt="image" src="https://github.com/user-attachments/assets/62053c99-d61a-44e7-ba24-f29f2277284e" />

After:
<img width="1524" height="544" alt="image" src="https://github.com/user-attachments/assets/79a9ed70-4af6-4912-8f68-0daf21d4e4f2" />

## Frontend
Make buttons w-full in secondary region

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Visit https://ugnext.netlify.app/lang
2. Visit /lang on the deployment URL: https://deploy-preview-380--ugnext.netlify.app/lang
3. Ensure buttons in secondary take up full width
4. Check other pages with secondary regions (e.g., https://ugnext.netlify.app/cbs) and compare to deployment https://deploy-preview-380--ugnext.netlify.app/cbs
6. Confirm with @Linda-Marciniak whether this aligns with brand