### PR TITLE
Fix links widget at mobile and full viewports when 4 or more are showing

### DIFF
--- a/components/client/widgets/links.tsx
+++ b/components/client/widgets/links.tsx
@@ -16,14 +16,14 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
   const count = data.links.length ?? 0;
   const classes = tv({
     slots: {
-      container: "mx-0 my-0 flex flex-col flex-wrap sm:flex-row gap-4 w-fit",
-      card: "h-full max-w-[32.2rem]",
+      container: "mx-0 my-0 flex flex-col flex-wrap sm:flex-row gap-4 w-full md:w-fit",
+      card: "h-full md:max-w-[32.2rem]",
       cardImage: "aspect-[4/3] w-full object-cover",
     },
     variants: {
       isLargeGrid: {
       true: {
-        container: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+        container: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full",
         },
       },
       centered: {
@@ -43,7 +43,7 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
       },
       divisibleByFour: {
         true: {
-          container: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4",
+          container: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full",
         },
       },
     },


### PR DESCRIPTION
# Summary of changes
Fix #381
Fix #337

Before:
<img width="1448" height="876" alt="image" src="https://github.com/user-attachments/assets/e19a5e4c-12ee-4e71-b621-4306e898d4e7" />
<img width="552" height="713" alt="image" src="https://github.com/user-attachments/assets/4cd70cd4-bea7-4744-9e02-108b1ffe5bea" />

After:
<img width="1486" height="867" alt="image" src="https://github.com/user-attachments/assets/db325d82-439d-464d-bfc6-d301316ca755" />
<img width="551" height="881" alt="image" src="https://github.com/user-attachments/assets/670bec9d-5152-4310-8a34-8e8f7f2dcd1e" />

Grids that are not divisible by 4 or large still appears with w-fit rather than w-full
<img width="1563" height="881" alt="image" src="https://github.com/user-attachments/assets/9d93cdb9-9cea-4b00-baff-9af439f830f6" />

## Frontend
Fix links widget at mobile and full viewports when 4 or more are showing

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Check https://deploy-preview-382--ugnext.netlify.app/lang
2. Check https://deploy-preview-382--ugnext.netlify.app/housing/communities (for less than 4)
3. Check https://deploy-preview-382--ugnext.netlify.app/studentexperience