### PR TITLE
Various news fixes

### DIFF
--- a/components/client/filterable-paginated-grid/filterable-paginated-grid.tsx
+++ b/components/client/filterable-paginated-grid/filterable-paginated-grid.tsx
@@ -84,9 +84,7 @@ export function FilterablePaginatedGrid<T>({
         </FilterablePaginatedGridContext.Provider>
       </div>
 
-      <Container>
-        <PaginatedGrid url={urlWithFilters} render={render} debounce={debounce} layout={layout} />
-      </Container>
+      <PaginatedGrid url={urlWithFilters} render={render} debounce={debounce} layout={layout} />
     </div>
   );
 }

--- a/components/client/news/news-card.tsx
+++ b/components/client/news/news-card.tsx
@@ -41,7 +41,7 @@ export function NewsCard({
     variants: {
       variant: {
         spotlight: {
-          content: "px-4 lg:px-0",
+          content: "lg:px-0",
           title: "text-black font-serif",
         },
         vertical: {
@@ -66,7 +66,6 @@ export function NewsCard({
   const { card, imageContainer, image, content, title, category } = newsCard({ variant });
 
   const img = data.hero?.image.variations?.[0];
-  const alt = data.hero?.image.alt ?? "";
 
   if (variant === "no-image") {
     return (

--- a/components/client/widgets/featured-news.tsx
+++ b/components/client/widgets/featured-news.tsx
@@ -56,7 +56,7 @@ function FeaturedNewsGrid({ data }: { data: FullFeaturedNews | FeaturedNewsFragm
   }
 
   return (
-    <Container className="peer">
+    <div className="peer">
       <Grid
         template={gridTemplate}
         gap={{
@@ -68,7 +68,7 @@ function FeaturedNewsGrid({ data }: { data: FullFeaturedNews | FeaturedNewsFragm
           <NewsCard variant="vertical" key={article.id} data={article} />
         ))}
       </Grid>
-    </Container>
+    </div>
   );
 }
 
@@ -79,11 +79,11 @@ function FeaturedNewsSpotlight({ data }: { data: FullFeaturedNews | FeaturedNews
 
   return (
     <div className="flex flex-col gap-6 pb-0">
-      <div className="flex flex-col lg:flex-row gap-6 lg:max-w-[137rem] lg:mx-auto lg:px-4">
+      <div className="flex flex-col lg:flex-row gap-6 lg:max-w-[137rem]">
         <div className="w-full lg:w-2/3">
           <NewsCard variant="spotlight" data={data.articles[0]} />
         </div>
-        <Container className="w-full lg:w-1/3 flex flex-col md:flex-row lg:flex-col gap-6 px-4 lg:p-0">
+        <Container className="w-full lg:w-1/3 flex flex-col md:flex-row lg:flex-col gap-6 lg:p-0 px-0">
           {data.articles?.slice(1, 3).map((article, index) => (
             <NewsCard variant="vertical" key={article.id} data={article} />
           ))}
@@ -131,13 +131,11 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
   }
 
   return (
-    <div>
+    <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0">
       {data.title && (
-        <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0 ps-0">
-          <Typography type="h3" as="h3">
-            {data.title}
-          </Typography>
-        </Container>
+        <Typography type="h3" as="h3">
+          {data.title}
+        </Typography>
       )}
 
       {variant === "spotlight" ? (
@@ -150,13 +148,11 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
         <FeaturedNewsList data={data} />
       )}
 
-      <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0">
-        <Link href={directory} className="w-full md:w-fit mt-4">
-          {Array.isArray(data.categories) && data.categories.length === 1
-            ? `More ${data.categories[0].name}`
-            : `More News`}
-        </Link>
-      </Container>
-    </div>
+      <Link href={directory} className="w-full md:w-fit mt-4">
+        {Array.isArray(data.categories) && data.categories.length === 1
+          ? `More ${data.categories[0].name}`
+          : `More News`}
+      </Link>
+    </Container>
   );
 }

--- a/components/client/widgets/featured-news.tsx
+++ b/components/client/widgets/featured-news.tsx
@@ -133,7 +133,7 @@ export function FeaturedNews({ data }: { data: FullFeaturedNews | FeaturedNewsFr
   return (
     <div>
       {data.title && (
-        <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0">
+        <Container className="peer-[ul]:px-0 peer-[.uofg-container]:px-0 ps-0">
           <Typography type="h3" as="h3">
             {data.title}
           </Typography>

--- a/components/client/widgets/featured-news.tsx
+++ b/components/client/widgets/featured-news.tsx
@@ -12,7 +12,7 @@ import { PrimaryNavigationContext } from "@/components/client/widgets/widget-sel
 
 function FeaturedNewsList({ data }: { data: FullFeaturedNews | FeaturedNewsFragment }) {
   return (
-    <ul className="peer flex flex-col gap-4">
+    <ul className="peer flex flex-col gap-4 py-4">
       {data.articles?.map((article) => (
         <li key={article.id}>
           <NewsCard data={article} variant={data.hideImages ? "no-image" : "vertical"} />


### PR DESCRIPTION
# Summary of changes
- Fix grid alignment on Featured News widget and News Search (listing) widget 
- Fix issue where a news article with a short title ended up not taking the full width (use a container instead of mx-auto)
- Remove padding-start from featured news widget title

See https://deploy-preview-384--ugnext.netlify.app/news
<img width="1528" height="740" alt="image" src="https://github.com/user-attachments/assets/4e80fff8-9c44-4303-93a9-d9ab5f4d2730" />

For list version at bottom
<img width="1549" height="680" alt="image" src="https://github.com/user-attachments/assets/87e993ed-9453-40b2-af1b-b6191b3f7f56" />

See https://deploy-preview-384--ugnext.netlify.app/ccmps/news
<img width="1482" height="847" alt="image" src="https://github.com/user-attachments/assets/1fd1d42f-19a0-42fc-b194-e465cb7b815e" />

And scroll down to ensure alignment
<img width="1517" height="906" alt="image" src="https://github.com/user-attachments/assets/6f5728b6-5040-4160-8575-316db8a546c8" />

Check mobile (everything should align as you scroll down)
<img width="554" height="912" alt="image" src="https://github.com/user-attachments/assets/ab53b1d3-a1cb-46b4-b1c0-ba10eae5c197" />


## Frontend
- Remove padding-start from featured news widget title
- Fix grid alignment by removing inner containers
- Align image cards with grid

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Increase and decrease the viewport for: https://deploy-preview-384--ugnext.netlify.app/ccmps/news, https://deploy-preview-384--ugnext.netlify.app/news and https://deploy-preview-384--ugnext.netlify.app/ccmps/news/directory
3. Confirm elements align with grid