### PR TITLE
Remove currentPage from breadcrumb for basic pages

### DIFF
--- a/data/drupal/route.ts
+++ b/data/drupal/route.ts
@@ -387,17 +387,13 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
 
   switch (data.route?.__typename) {
     case "RouteInternal":
-      if (!data.route.entity || !("title" in data.route.entity)) {
+      if (!data.route.entity || !("title" in data.route.entity) || !Array.isArray(data.route.breadcrumbs)) {
         return null;
       }
 
       let currentPage = {
         title: data.route.entity.title,
       };
-
-      if (!Array.isArray(data.route.breadcrumbs)) {
-        return [currentPage];
-      }
 
       let breadcrumbPath = filterBreadcrumbs(data.route.breadcrumbs, currentPage);
 
@@ -416,7 +412,7 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
           primary_navigation
         );
         if (!isPageInMenu) {
-          return [primaryNavigationHome, currentPage];
+          return [primaryNavigationHome];
         }
 
         // Only add Primary Nav Homepage URL if NOT already at start of breadcrumbPath
@@ -430,16 +426,16 @@ export async function getRouteBreadcrumbs(url: string, primary_navigation: strin
           // Pages in multiple menus can have breadcrumb path from a different menu than Primary Navigation
           // If page in multiple menus, return [Primary Nav Home > currentPage]
           if (data.route.entity.primaryNavigation?.menuName !== primary_navigation) {
-            return [primaryNavigationHome, currentPage];
+            return [primaryNavigationHome];
           }
 
           // Default return
-          return [primaryNavigationHome, ...breadcrumbPath, currentPage];
+          return [primaryNavigationHome, ...breadcrumbPath];
         }
       }
 
       // Handle content without Primary Navigation
-      return [...breadcrumbPath, currentPage];
+      return [...breadcrumbPath];
     default:
       return null;
   }


### PR DESCRIPTION
# Summary of changes
Fix #349

Instead of:
<img width="625" height="139" alt="image" src="https://github.com/user-attachments/assets/519f53d8-0945-448c-962a-33e24650772c" />

We now see:
<img width="594" height="131" alt="image" src="https://github.com/user-attachments/assets/bde773d8-f767-4bc9-a082-52bc24a4f42b" />



## Frontend
Remove currentPage from breadcrumb for basic pages

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Check a primary nav homepage: https://deploy-preview-385--release-ugnext.netlify.app/research
2. Check a page with a long breadcrumb: https://deploy-preview-385--release-ugnext.netlify.app/research/about/office-of-research-units/research-services-office/animal-care-services/archived-newsletters/issue-1
3. Check a profile listing page: https://deploy-preview-385--release-ugnext.netlify.app/csahs/people
4. Check a profile https://deploy-preview-385--release-ugnext.netlify.app/ovc/pathobiology/people/faculty/khalil-karimi