### PR TITLE
Add section context for statistics gradient

### DIFF
--- a/components/client/widgets/statistics.tsx
+++ b/components/client/widgets/statistics.tsx
@@ -12,15 +12,20 @@ import type { StatisticsFragment } from "@/lib/graphql/types";
 import { nanoid } from "nanoid";
 import NextLink from "next/link";
 import { Link } from "@uoguelph/react-components/link";
-import React from "react";
+import { useContext } from "react";
+import { SectionContext } from "@/components/client/section";
 
 export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
+  const context = useContext(SectionContext);
+
   const variant = data?.style?.name
     ?.toLowerCase()
     .replace(/\s/g, "-")
     .replace("colour", "color")
-    .replace("gradient-of-solid-colors", "solid-colors-full")
+    .replace("gradient-of-solid-colors", context === null ? "solid-colors-full" : "solid-colors-no-gap")
     .replace("light-blue", "light-grey") as StatisticsProps["variant"];
+
+console.log(variant);
 
   return (
     <StatisticsComponent id={`statistics-${data.uuid}`} variant={variant}>

--- a/components/client/widgets/statistics.tsx
+++ b/components/client/widgets/statistics.tsx
@@ -25,8 +25,6 @@ export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
     .replace("gradient-of-solid-colors", context === null ? "solid-colors-full" : "solid-colors-no-gap")
     .replace("light-blue", "light-grey") as StatisticsProps["variant"];
 
-console.log(variant);
-
   return (
     <StatisticsComponent id={`statistics-${data.uuid}`} variant={variant}>
       {data?.content.map((statistic, index) => {


### PR DESCRIPTION
# Summary of changes
Fix #354

Before:
<img width="1579" height="757" alt="image" src="https://github.com/user-attachments/assets/e32d0bd9-2b18-416b-aab4-89c6317d82fd" />

After:
<img width="1556" height="815" alt="image" src="https://github.com/user-attachments/assets/a855aa23-8c32-4c64-bea9-c1bfc85d9b00" />


## Frontend
Use context to determine which gradient variant to use

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Visit https://deploy-preview-386--release-ugnext.netlify.app/lang/careers/employment
2. Visit https://deploy-preview-386--release-ugnext.netlify.app/widget-examples#statistics and confirm full width gradient (outside a section) still appears using the full width of the screen