### PR TITLE
Fix news-share modal container in safari

### DIFF
--- a/components/client/news/news-share.tsx
+++ b/components/client/news/news-share.tsx
@@ -9,6 +9,7 @@ import { Typography } from "@uoguelph/react-components/typography";
 import { faBluesky, faFacebookF, faLinkedin, faXTwitter } from "@awesome.me/kit-7993323d0c/icons/classic/brands";
 import { faEnvelope } from "@awesome.me/kit-7993323d0c/icons/classic/solid";
 import { usePathname } from "next/navigation";
+import { Container } from "@uoguelph/react-components/container";
 
 export function NewsShare({ title }: { title: string }) {
   const [open, setOpen] = useState(false);
@@ -17,7 +18,7 @@ export function NewsShare({ title }: { title: string }) {
   const classes = tv({
     slots: {
       button: "inline-flex cursor-pointer items-center gap-1 pl-4 border-l-2 border-grey-light-focus",
-      container: "flex flex-col gap-2 bg-white p-6 w-dvw max-w-fit",
+      container: "flex flex-col gap-2 bg-white p-6 w-dvw max-w-fit w-fit",
       heading: "mt-0",
       buttons: "flex gap-2 flex-wrap",
       shareButton:
@@ -49,6 +50,7 @@ export function NewsShare({ title }: { title: string }) {
       </button>
 
       <Modal open={open} onClose={() => setOpen(false)} centered>
+
         <div className={classes.container()}>
           <Typography as="span" type="h2" className={classes.heading()}>
             Share this article


### PR DESCRIPTION
# Summary of changes
Fix #366

Before:
<img width="3376" height="1298" alt="image" src="https://github.com/user-attachments/assets/ef3a9d22-ed6a-4078-b1d1-2755a4d1f5b0" />

After:
<img width="1463" height="718" alt="image" src="https://github.com/user-attachments/assets/8dec0361-8f1b-4940-b228-e17f4a9fbad6" />


## Frontend
- Add w-fit in addition to max-w-fit to ensure modal is centred in Safari

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. In safari, visit a news article (e.g., http://localhost:3000/news/2026/11/made-ontario-research-shields-farmers-emerging-threats)
2. Select Share
3. Ensure the modal appears centred (i.e., as expected)