### PR TITLE
Display external link button when News Link text field is populated

### DIFF
--- a/components/server/news.tsx
+++ b/components/server/news.tsx
@@ -16,6 +16,7 @@ import { Link as UofGLink } from "@uoguelph/react-components/link";
 import { NewsTimeEstimate } from "@/components/client/news/news-time-estimate";
 import { ProcessedWidget } from "@/data/drupal/widgets";
 import { NewsShare } from "@/components/client/news/news-share";
+import { Button } from "@uoguelph/react-components/button";
 
 function NewsBreadcrumbs({ article }: { article: FullNewsArticle }) {
   return (
@@ -131,7 +132,25 @@ function NewsShareAndReadInfo({ article }: { article: FullNewsArticle }) {
     </div>
   );
 }
+function NewsExternalLinkButton({ article }: { article: FullNewsArticle }) {
+  if (article.externallyLinked || !article.externalLink?.title || !article.externalLink?.url) {
+    return <></>;
+  }
 
+  return (
+    <div className="mt-4">
+      <Button
+        as="a"
+        href={article.externalLink.url}
+        color="red"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {article.externalLink.title}
+      </Button>
+    </div>
+  );
+}
 export async function News({ id }: { id: string }) {
   const article = await getNewsArticle(id);
 
@@ -213,6 +232,7 @@ export async function News({ id }: { id: string }) {
             primary={[
               <NewsShareAndReadInfo article={article} key="share-and-read" />,
               ...primaryWidgets.map((widget, index) => <WidgetSelector key={index} data={widget} />),
+              <NewsExternalLinkButton article={article} key="external-link" />
             ]}
             secondary={[
               <NewsSidebar article={article} key="sidebar" />,


### PR DESCRIPTION
# Summary of changes
Added a button to news articles that displays an external link when the News Link field has both a URL and link text populated. If the URL is present but no link text is provided, the user is redirected directly to the external URL instead of viewing the article.

## Frontend

- Added NewsExternalLinkButton component in components/server/news.tsx that renders a red UofG Button when externalLink.url and externalLink.title are both present and externallyLinked is false

## Backend
No change
## Checklist

- [ ] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [ ] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to a news article in CH ss-chnews https://ss-chnews-chug.pantheonsite.io/node/8156/edit and populate both the URL and News Link field
- Visit the article on the Netlify preview https://deploy-preview-311--ugnext.netlify.app/news/2026/04/test-news-external-url— confirm the red button appears at the bottom of the content with the correct link text and URL
- Remove the link text, keep the URL and toggle on the button for redirect — confirm the article redirects directly to the external URL
- Leave both fields empty — confirm no button appears and article loads normally
<img width="687" height="625" alt="Screenshot 2026-05-06 at 4 30 59 PM" src="https://github.com/user-attachments/assets/0974a547-3799-44fa-bd22-bc27c233646e" />
