### PR TITLE
Do not render home if no menu in breadcrumb + keep spacing consistent

### DIFF
--- a/components/server/breadcrumbs.tsx
+++ b/components/server/breadcrumbs.tsx
@@ -9,8 +9,8 @@ export async function Breadcrumbs({ url, primary_navigation }: { url?: string, p
   const breadcrumbs = url ? await getRouteBreadcrumbs(url, primary_navigation) : [];
 
   return (
-    <BreadcrumbsComponent className="text-base">
-      <BreadcrumbHome href="/" />
+    <BreadcrumbsComponent className="text-base"> 
+      {breadcrumbs && breadcrumbs?.length > 0 && <BreadcrumbHome href="/" />}
 
       {breadcrumbs?.map((breadcrumb, index) => {
         if ("url" in breadcrumb && breadcrumb.url) {


### PR DESCRIPTION
# Summary of changes
Fix #392 
Do not render home if no menu in breadcrumb + keep spacing consistent

Before
<img width="1544" height="588" alt="image" src="https://github.com/user-attachments/assets/53f48f50-9846-412f-9871-942634d2bcd5" />

After
<img width="1560" height="614" alt="image" src="https://github.com/user-attachments/assets/1ad8298e-aaed-4ebf-9631-909d5e73b85b" />


## Frontend
Do not render home if no menu in breadcrumb + keep spacing consistent

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Visit https://deploy-preview-393--release-ugnext.netlify.app/professional-course-based-masters-program (should be no breadcrumb home icon)
2. Visit https://deploy-preview-393--release-ugnext.netlify.app/miranda-testing (should be no breadcrumb home icon)
3. Visit https://deploy-preview-393--release-ugnext.netlify.app/ovc and https://deploy-preview-393--release-ugnext.netlify.app/research/about/office-of-research-units/research-services-office/animal-care-services/archived-newsletters/issue-1 to confirm breadcrumbs still working with home icon