### PR TITLE
remove legacy news feature new on ovc homepage

### DIFF
--- a/app/ovc/page.tsx
+++ b/app/ovc/page.tsx
@@ -3,8 +3,6 @@ import { getRoute } from "@/data/drupal/route";
 import { notFound } from "next/navigation";
 import { Container } from "@uoguelph/react-components/container";
 import { OVCCards } from "@/components/client/ovc/ovc-cards";
-import { OVCFeaturedNews } from "@/components/client/ovc/ovc-featured-news";
-import { getFeaturedLegacyNewsArticles } from "@/data/drupal/legacy-news";
 import { Metadata } from "next";
 import { CustomFooter } from "@/components/server/custom-footer";
 
@@ -24,7 +22,7 @@ export default async function OVCHome() {
     notFound();
   }
 
-  const featuredNews = await getFeaturedLegacyNewsArticles();
+
 
   return (
     <BasicPage
@@ -33,7 +31,6 @@ export default async function OVCHome() {
         <>
           <Container>
             {/* @ts-ignore */}
-            <OVCFeaturedNews articles={featuredNews} />
             <OVCCards />
           </Container>
           <CustomFooter id="758" />

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ugnext",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "ugnext",


### PR DESCRIPTION
# Summary of changes
Removed the Featured News (Custom code - Legacy News) from the OVC home page

## Frontend
Removed all references to Legacy news and ovc featured news (legacy news) forom the OVC home page (OVC - Page.

## Backend
No changes

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ N/A] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan
The Featured News seconton will be gone from /ovc page. 

After merge - I will add the new Featured News to the Content Hub page /ovc
https://deploy-preview-394--ugnext.netlify.app/ovc
vs 
https://www.uoguelph.ca/ovc


