### PR TITLE
Update statistics text color for light-grey and left-border variants

### DIFF
--- a/components/client/widgets/statistics.tsx
+++ b/components/client/widgets/statistics.tsx
@@ -14,6 +14,7 @@ import NextLink from "next/link";
 import { Link } from "@uoguelph/react-components/link";
 import { useContext } from "react";
 import { SectionContext } from "@/components/client/section";
+import { tv } from "tailwind-variants";
 
 export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
   const context = useContext(SectionContext);
@@ -25,6 +26,28 @@ export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
     .replace("gradient-of-solid-colors", context === null ? "solid-colors-full" : "solid-colors-no-gap")
     .replace("light-blue", "light-grey") as StatisticsProps["variant"];
 
+  const classes = tv({
+    slots: {
+      represents: "",
+      link: "text-inherit! outline-inherit!",
+    },
+    variants: {
+      variant: {
+        "light-grey": {
+          represents: "text-body-copy-on-light!",
+        },
+        "solid-colors-full": "",
+        "solid-colors-no-gap": "",
+        "left-border": {
+          represents: "text-body-copy-on-light!",
+        },
+        "solid-colors": "",
+      },
+    },
+  });
+
+  const { represents: representsClasses, link: linkClasses } = classes({ variant: variant });
+
   return (
     <StatisticsComponent id={`statistics-${data.uuid}`} variant={variant}>
       {data?.content.map((statistic, index) => {
@@ -34,7 +57,7 @@ export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
               <i className={`${statistic.fontAwesomeIcon} fa-4x pt-6 -mb-6`}></i>
             )}
             <StatisticsItemValue>{statistic?.value}</StatisticsItemValue>
-            <StatisticsItemRepresents>
+            <StatisticsItemRepresents className={representsClasses()}>
               <HtmlParser
                 html={statistic?.represents?.processed}
                 instructions={[
@@ -43,7 +66,7 @@ export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
                     processNode: (node, props, children) => {
                       return (
                         <Link
-                          className="text-inherit! outline-inherit!"
+                          className={linkClasses({ variant: variant })}
                           {...props}
                           key={nanoid()}
                           href={props.href as string}

--- a/components/client/widgets/statistics.tsx
+++ b/components/client/widgets/statistics.tsx
@@ -28,25 +28,24 @@ export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
 
   const classes = tv({
     slots: {
-      represents: "",
       link: "text-inherit! outline-inherit!",
     },
     variants: {
       variant: {
         "light-grey": {
-          represents: "text-body-copy-on-light!",
+          link: "text-body-copy-link-on-light!",
         },
         "solid-colors-full": "",
         "solid-colors-no-gap": "",
         "left-border": {
-          represents: "text-body-copy-on-light!",
+          link: "text-body-copy-link-on-light!",
         },
         "solid-colors": "",
       },
     },
   });
 
-  const { represents: representsClasses, link: linkClasses } = classes({ variant: variant });
+  const { link: linkClasses } = classes({ variant: variant });
 
   return (
     <StatisticsComponent id={`statistics-${data.uuid}`} variant={variant}>
@@ -57,7 +56,7 @@ export function StatisticsWidget({ data }: { data: StatisticsFragment }) {
               <i className={`${statistic.fontAwesomeIcon} fa-4x pt-6 -mb-6`}></i>
             )}
             <StatisticsItemValue>{statistic?.value}</StatisticsItemValue>
-            <StatisticsItemRepresents className={representsClasses()}>
+            <StatisticsItemRepresents>
               <HtmlParser
                 html={statistic?.represents?.processed}
                 instructions={[


### PR DESCRIPTION
# Summary of changes
Fixes https://github.com/ccswbs/ugnext/issues/396

## Frontend
- Added tailwind variants object to set text color classes for links in statistics represents.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-397--ugnext.netlify.app/widget-examples, ensure the links have correct color set in light-grey and left-border variants.
