### PR TITLE
Simplify Links Widget classes and add missing description field

### DIFF
--- a/components/client/widgets/links.tsx
+++ b/components/client/widgets/links.tsx
@@ -11,11 +11,12 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
   if (!data.links || data.links.length === 0) return null;
 
   const title = data.title?.trim();
+  const description = data.linksDescription;
   const useCards = data.links.some((link) => Boolean(link.image));
   const containerClass = "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full gap-4";
   const cardClass = "h-full md:max-w-[32.2rem]";
   const cardImageClass = "aspect-[4/3] w-full object-cover";
-
+  
   return (
     <div id={`links-${data.uuid}`} className="mb-5 py-4">
       {title && (
@@ -23,6 +24,11 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
           {title}
         </Typography>
       )}
+      {description && (
+        <Typography type="body" as="p" className="mb-4">
+          {description}
+        </Typography>)
+      }
 
       {useCards ? (
         <div className={containerClass}>

--- a/components/client/widgets/links.tsx
+++ b/components/client/widgets/links.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent, CardTitle, CardImage } from "@uoguelph/react-compone
 import { List, ListItem } from "@uoguelph/react-components/list";
 import { Link } from "@uoguelph/react-components/link";
 import NextLink from "next/link";
-import { tv } from "tailwind-variants";
 import type { LinksFragment } from "@/lib/graphql/types";
 import { Typography } from "@uoguelph/react-components/typography";
 import { slugify } from "@/lib/string-utils";
@@ -13,64 +12,10 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
 
   const title = data.title?.trim();
   const useCards = data.links.some((link) => Boolean(link.image));
-  const count = data.links.length ?? 0;
-  const classes = tv({
-    slots: {
-      container: "mx-0 my-0 flex flex-col flex-wrap sm:flex-row gap-4 w-full md:w-fit",
-      card: "h-full md:max-w-[32.2rem]",
-      cardImage: "aspect-[4/3] w-full object-cover",
-    },
-    variants: {
-      isLargeGrid: {
-      true: {
-        container: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full",
-        },
-      },
-      centered: {
-        true: {
-          container: "mx-auto justify-center",
-        },
-      },
-      divisibleByTwo: {
-        true: {
-          container: "",
-        },
-      },
-      divisibleByThree: {
-        true: {
-          container: "",
-        },
-      },
-      divisibleByFour: {
-        true: {
-          container: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full",
-        },
-      },
-    },
-    compoundVariants: [
-      {
-        divisibleByTwo: true,
-        divisibleByThree: false,
-        divisibleByFour: false,
-        class: {
-          container: "grid grid-cols-1 sm:grid-cols-2",
-        },
-      },
-      {
-        divisibleByThree: true,
-        divisibleByFour: false,
-        class: {
-          container: "grid grid-cols-1 sm:grid-cols-3",
-        },
-      },
-    ],
-  })({
-    centered: false,
-    isLargeGrid: count > 8, 
-    divisibleByTwo: count % 2 === 0,
-    divisibleByThree: count % 3 === 0,
-    divisibleByFour: count % 4 === 0,
-  });
+  // const count = data.links.length;
+  const containerClass = "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full gap-4";
+  const cardClass = "h-full md:max-w-[32.2rem]";
+  const cardImageClass = "aspect-[4/3] w-full object-cover";
 
   return (
     <div id={`links-${data.uuid}`} className="mb-5 py-4">
@@ -81,7 +26,7 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
       )}
 
       {useCards ? (
-        <div className={classes.container()}>
+        <div className={containerClass}>
           {data.links?.map((link, index) => {
             const url = link.url?.url;
             const title = link.url?.title;
@@ -96,7 +41,7 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
                 as={NextLink}
                 id={`link-${data.uuid}`}
                 href={url}
-                className={classes.card()}
+                className={cardClass}
                 centered
                 key={url + index}
               >
@@ -107,7 +52,7 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
                     width={image.width}
                     height={image.height}
                     alt={image.alt ?? ""}
-                    className={classes.cardImage()}
+                    className={cardImageClass}
                     sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
                   />
                 )}

--- a/components/client/widgets/links.tsx
+++ b/components/client/widgets/links.tsx
@@ -12,7 +12,6 @@ export function LinksWidget({ data }: { data: LinksFragment }) {
 
   const title = data.title?.trim();
   const useCards = data.links.some((link) => Boolean(link.image));
-  // const count = data.links.length;
   const containerClass = "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 lg:w-full gap-4";
   const cardClass = "h-full md:max-w-[32.2rem]";
   const cardImageClass = "aspect-[4/3] w-full object-cover";


### PR DESCRIPTION
# Summary of changes
Fixes #403 

## Frontend

This pull request simplifies the layout logic and improves the maintainability of the `LinksWidget` component. It removes the dependency on `tailwind-variants` for dynamic class generation, replacing it with static CSS class strings, and adds support for displaying a description for the links section.

**Layout and Styling Simplification:**
* Removed the use of `tailwind-variants` and its dynamic class logic in favor of static CSS class strings for the container, card, and card image elements. This makes the code easier to read and maintain. [[1]](diffhunk://#diff-85c86a8422bde65dd29bc9c4df9d1b11d3404f6eeba10147e0cf845770ab0a72L6) [[2]](diffhunk://#diff-85c86a8422bde65dd29bc9c4df9d1b11d3404f6eeba10147e0cf845770ab0a72R14-R18) [[3]](diffhunk://#diff-85c86a8422bde65dd29bc9c4df9d1b11d3404f6eeba10147e0cf845770ab0a72L99-R49) [[4]](diffhunk://#diff-85c86a8422bde65dd29bc9c4df9d1b11d3404f6eeba10147e0cf845770ab0a72L110-R60)

**Feature Enhancement:**
* Added support for displaying a `linksDescription` (if present) as a paragraph above the links, improving the widget's flexibility and accessibility. [[1]](diffhunk://#diff-85c86a8422bde65dd29bc9c4df9d1b11d3404f6eeba10147e0cf845770ab0a72R14-R18) [[2]](diffhunk://#diff-85c86a8422bde65dd29bc9c4df9d1b11d3404f6eeba10147e0cf845770ab0a72R27-R34)

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to https://deploy-preview-406--ugnext.netlify.app/links-widget-test
- Compare and contrast with current version at https://ugnext.netlify.app/links-widget-test
- Ensure page is responsive at varying screen widths
- Check existing pages using the Links Widget, e.g. https://ugnext.netlify.app/housing and https://ugnext.netlify.app/studentexperience