### PR TITLE
Fix homepage image flicker on first load

### DIFF
--- a/components/client/home/spotlight-hero.tsx
+++ b/components/client/home/spotlight-hero.tsx
@@ -5,11 +5,8 @@ import Image from "next/image";
 import { tv } from "tailwind-variants";
 import type { SpotlightHero as SpotlightHeroData } from "@/data/drupal/spotlight";
 import Link from "next/link";
-import { useMediaQuery } from "@/lib/use-media-query";
 
 export const SpotlightHero = ({ data }: { data: SpotlightHeroData }) => {
-  const showLargeImage = useMediaQuery("(min-width: 768px)");
-
   const classes = tv({
     slots: {
       hero: "w-full [&_.uofg-hero-img]:object-cover",
@@ -22,15 +19,15 @@ export const SpotlightHero = ({ data }: { data: SpotlightHeroData }) => {
   return (
     <Hero
       variant="spotlight"
-      src={showLargeImage ? data.image.url : data.thumbnail.url}
+      src={data.image.url}
       alt={data.image.alt}
-      width={showLargeImage ? data.image.width : data.thumbnail.width}
-      height={showLargeImage ? data.image.height : data.thumbnail.height}
+      width={data.image.width}
+      height={data.image.height}
       sizes="100vw"
       as={Image}
+      priority
       alignment={(data.captionAlignment ?? "left") as HeroProps["alignment"]}
       className={hero()}
-      preload={true}
     >
       <HeroTitle as="h2" className={title()}>
         {data.title}


### PR DESCRIPTION
# Summary of changes
Fixes #405 by removing logic which loaded thumbnail first before switching to the large image (root cause of the flicker)

## Frontend

This pull request simplifies the `SpotlightHero` component by removing responsive image logic and always displaying the main image, regardless of screen size. It also updates the way the image is loaded for improved performance.

**Image handling simplification:**

* Removed the `useMediaQuery` hook and the conditional logic that switched between the main image and thumbnail based on screen size—now only `data.image` is used for `src`, `width`, and `height`. [[1]](diffhunk://#diff-095a4caa1c877bb86df2507e0e9afaf92c0cbd6bad00277ddea74c1a65cf4653L8-L12) [[2]](diffhunk://#diff-095a4caa1c877bb86df2507e0e9afaf92c0cbd6bad00277ddea74c1a65cf4653L25-L33)

**Image loading and performance:**

* Added the `priority` prop to the `Image` component to ensure the hero image is preloaded for better performance, and removed the redundant `preload` prop.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to https://deploy-preview-407--ugnext.netlify.app/ and confirm it loads without a flicker from the large, blurry thumbnail to the actual image. Test in different browsers if possible.
- For performance, see https://pagespeed.web.dev/analysis/https-deploy-preview-407--ugnext-netlify-app/t27tp9rtr2?form_factor=mobile and compare to https://pagespeed.web.dev/analysis/https-ugnext-netlify-app/7igpyuyiim?form_factor=mobile (in other words, eliminating `useMediaQuery` has no negative impact on mobile load times - in contrast, the fix has a much higher mobile performance score of 93 vs 56 for the original)