### PR TITLE
Fix financial-economics link

### DIFF
--- a/data/yaml/programs/graduate/programs/financial-economics.yml
+++ b/data/yaml/programs/graduate/programs/financial-economics.yml
@@ -1,6 +1,6 @@
 id: financial-economics
 name: Financial Economics
-url: https://graduatestudies.uoguelph.ca/prospective-students/economics-and-finance
+url: https://graduatestudies.uoguelph.ca/programs/financial-economics
 degrees:
   - master-of-arts
 types:


### PR DESCRIPTION
# Summary of changes
Fix broken financial-economics link on graduate program search

## Frontend
Fix broken financial-economics link on graduate program search

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to /programs/graduate
2. Search for Financial Economics and confirm link goes to actual page rather than page not found