### PR TITLE
Fix `getMenuByPrimaryNavigation` to handle "no-menu" case properly

### DIFF
--- a/data/drupal/primary-navigation.ts
+++ b/data/drupal/primary-navigation.ts
@@ -79,7 +79,7 @@ export async function getMenuLinkByURI(link_uri: string, menu_name: string) {
 }
 
 export async function getMenuByPrimaryNavigation(primaryNavigation?: NavigationFragment | null) {
-  if (!primaryNavigation || !primaryNavigation?.menuName || primaryNavigation.menuName === "NO_MENU") {
+  if (!primaryNavigation || !primaryNavigation?.menuName || primaryNavigation.menuName === "no-menu") {
     return null;
   }
 


### PR DESCRIPTION
# Summary of changes
Was incorrectly checking against "NO_MENU" instead of actual value "no-menu".

## Frontend
- Changed check in menu fetch to check for "no-menu"

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-416--ugnext.netlify.app/about, ensure page builds correctly.