### PR TITLE
Add top level menu items to graphql menu fetch function.

### DIFF
--- a/components/server/header.tsx
+++ b/components/server/header.tsx
@@ -10,6 +10,8 @@ async function HeaderSubNavigationItem({ item }: { item: MenuItem }) {
   if (item.children && item.children.length > 0) {
     return (
       <HeaderMenu title={item.title}>
+        {item.url && <HeaderLink href={item.url}>{item.title}</HeaderLink>}
+
         {item.children.map((child, index) => (
           <HeaderMenuItem key={index}>
             <HeaderSubNavigationItem item={child as MenuItem} />

--- a/components/server/header.tsx
+++ b/components/server/header.tsx
@@ -10,7 +10,11 @@ async function HeaderSubNavigationItem({ item }: { item: MenuItem }) {
   if (item.children && item.children.length > 0) {
     return (
       <HeaderMenu title={item.title}>
-        {item.url && <HeaderLink href={item.url}>{item.title}</HeaderLink>}
+        {item.url && (
+          <HeaderMenuItem>
+            <HeaderLink href={item.url}>{item.title}</HeaderLink>
+          </HeaderMenuItem>
+        )}
 
         {item.children.map((child, index) => (
           <HeaderMenuItem key={index}>


### PR DESCRIPTION
# Summary of changes
Since switching to GraphQL instead of linkset for menus, it seems the top level menu links are not appearing, this PR fixes that.

## Frontend
- Update header.tsx to render top level link if it exists.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-418--ugnext.netlify.app/continuing-studies ensure top level links appear