### PR TITLE
Fix low-resolution spotlight image display on Featured News

### DIFF
--- a/components/client/news/news-card.tsx
+++ b/components/client/news/news-card.tsx
@@ -66,6 +66,7 @@ export function NewsCard({
   const { card, imageContainer, image, content, title, category } = newsCard({ variant });
 
   const img = data.hero?.image.variations?.[0];
+  const imgLarge = data.hero?.image.variations?.[1];
 
   if (variant === "no-image") {
     return (
@@ -83,10 +84,11 @@ export function NewsCard({
     <Link key={data.id} href={url} className={twMerge(card(), className)}>
       <div className={imageContainer()}>
         <Image
-          src={img?.url ?? defaultImage.src}
+          src={(variant === "spotlight" ? imgLarge?.url : img?.url) ?? defaultImage.src}
           alt=""
-          width={`${img?.width ?? 800}`}
-          height={`${img?.height ?? 450}`}
+          width={`${(variant === "spotlight" ? imgLarge?.width : img?.width) ?? 800}`}
+          height={`${(variant === "spotlight" ? imgLarge?.height : img?.height) ?? 450}`}
+          loading={variant === "spotlight" ? "eager" : undefined}
           className={image()}
         />
       </div>

--- a/data/drupal/news.ts
+++ b/data/drupal/news.ts
@@ -32,7 +32,7 @@ export const NEWS_WITHOUT_CONTENT = gql(/* gql */ `
         url
         width
         height
-        variations(styles: FOCAL_POINT600X400) {
+        variations(styles: [FOCAL_POINT600X400, FOCAL_POINT900X506]) {
           url
           width
           height


### PR DESCRIPTION
# Summary of changes
Fixes #412 

## Frontend

This pull request updates the `NewsCard` component to improve image handling, especially for the "spotlight" variant, and ensures the correct image sizes are fetched and displayed. The most important changes are:

**Image Handling Improvements:**

* The GraphQL query in `news.ts` now requests both `FOCAL_POINT600X400` and `FOCAL_POINT900X506` image variations, enabling access to a larger image for the "spotlight" variant.
* In `news-card.tsx`, the component selects the larger image variation (`imgLarge`) for the "spotlight" variant and uses the standard image (`img`) for other variants.
* The `Image` component now dynamically sets its `src`, `width`, and `height` attributes based on the selected image variation and variant, defaulting to a fallback image if necessary.
* The "spotlight" variant images are set to load eagerly for improved perceived performance.

## Backend
New image style added: https://api.liveugconthub.uoguelph.dev/admin/config/media/image-styles/manage/focal_point_900x506

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-419--ugnext.netlify.app/csahs and verify the new, larger image style is used, i.e. use the browser inspector to compare intrinsic size with rendered size
2. Visually compare it with the current version on https://ugnext.netlify.app/csahs and verify it's no longer blurry/low-resolution

**Note:** The live image might be different from the PR deploy if further news articles are published between now and whenever this PR is reviewed. Also, the images will be cropped differently since the live version forces a 3:2 image into a 16:9 display area. In contrast, the new `imgLarge` style already uses a 16:9 ratio.