### PR TITLE
Replace multiple dashes with a single underscore when converting machine name for menu graphql

### DIFF
--- a/data/drupal/primary-navigation.ts
+++ b/data/drupal/primary-navigation.ts
@@ -93,7 +93,7 @@ export async function getMenuByPrimaryNavigation(primaryNavigation?: NavigationF
     `),
     variables: {
       // @ts-ignore
-      name: primaryNavigation.menuName.toUpperCase().replaceAll("-", "_"),
+      name: primaryNavigation.menuName.toUpperCase().replaceAll(/-+/g, "_"),
     },
   });
 


### PR DESCRIPTION
# Summary of changes
Replace multiple dashes with a single underscore when converting machine name for menu graphql

## Frontend
Replace multiple dashes with a single underscore when converting machine name for menu graphql

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. View https://deploy-preview-420--ugnext.netlify.app/profile/rosario-gomez and confirm it shows
2. View various pages with menus (e.g., https://deploy-preview-420--ugnext.netlify.app/continuing-studies)
3. View various pages without menus (e.g., https://deploy-preview-420--ugnext.netlify.app/about)