### PR TITLE
Ensure link child elements inherit correct text colour

### DIFF
--- a/components/client/html-parser/instructions/link.tsx
+++ b/components/client/html-parser/instructions/link.tsx
@@ -42,7 +42,7 @@ export const LinkInstruction: HTMLParserInstruction = {
       });
 
       // Exclude certain classes
-      const classes = twMerge("mr-3 mb-3", updatedClassname);
+      const classes = twMerge("mr-3 mb-3 [&_strong]:!text-inherit [&_em]:!text-inherit [&_*]:!text-inherit", updatedClassname);
 
       switch (className.match(/btn-(?:outline-)?(\w*)/)?.[1]) {
         case "primary":


### PR DESCRIPTION
# Summary of changes
Fixes #427 

## Frontend

This pull request makes a small styling update to the `LinkInstruction` component. The change ensures that all descendant elements of the link (such as `strong`, `em`, and any others) inherit the text color from their parent, which helps maintain consistent styling.

* Updated the `classes` assignment in `link.tsx` to enforce inherited text color for all descendant elements using Tailwind utility classes.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [NA] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [NA] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to https://deploy-preview-429--ugnext.netlify.app/admission/undergraduate
2. Ensure the "Sign Up to Learn More" button has white text instead of dark