### PR TITLE
Add veterinary to the list of search terms for population medicine

### DIFF
--- a/data/yaml/programs/graduate/programs/population-medicine.yml
+++ b/data/yaml/programs/graduate/programs/population-medicine.yml
@@ -32,5 +32,6 @@ tags:
   - public health
   - science
   - sustainable
+  - veterinary
   - water
   - waterbourne diseases


### PR DESCRIPTION
# Summary of changes
Add veterinary to the list of search terms for population medicine so it will appear in searches for "vet..."
<img width="2984" height="1398" alt="image" src="https://github.com/user-attachments/assets/9fed704c-ab06-40e9-8d2b-9aeb4ac6ecee" />


## Frontend
Add veterinary to the list of search terms for population medicine so it will appear in searches for "vet..."

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Do a search for "vet" in /programs/graduate.
2. Confirm Population Medicine shows up.