### PR TITLE
Set useContentsClass to false when button has icon

### DIFF
--- a/components/client/widgets/button.tsx
+++ b/components/client/widgets/button.tsx
@@ -136,7 +136,10 @@ export const ButtonWidget = ({ data, column }: { data: ButtonsFragment; column: 
         onClick={analyticsHandler}
       >
         {icon && icon.data && <i className={classes.icon()} aria-hidden="true"></i>}
-        <HtmlParser html={title} />
+        <HtmlParser
+          html={title}
+          {...(icon ? { useContentsClass: false } : {})}
+        />
       </Button>
     </div>
   );


### PR DESCRIPTION
# Summary of changes
Fixes #428 

## Frontend

This pull request makes a small change to the `ButtonWidget` component to improve how the `HtmlParser` is rendered when an icon is present. Now, if an icon is shown, the `useContentsClass` prop is explicitly set to `false` for `HtmlParser`.

- [`components/client/widgets/button.tsx`](diffhunk://#diff-99398d40f6a2bac7f8d4d6afddc512daf744e9799f76d90f0d8da1a7b14365b9L139-R142): Conditionally passes `useContentsClass={false}` to `HtmlParser` when an icon is present to prevent text misalignment
## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger

# Test Plan

- Go to https://deploy-preview-433--ugnext.netlify.app/admission/undergraduate
- Verify the blue buttons with yellow icons have correct text alignment (compare and contrast with [the live version on gus](https://www.uoguelph.ca/admission/undergraduate/))
- Go to https://deploy-preview-433--ugnext.netlify.app/studentexperience
- Verify the sidebar buttons with icons continue to display as expected as do the buttons without icons