### PR TITLE
Update summary to use minimum duration value as default

### DIFF
--- a/components/client/programs/graduate/graduate-program-summary.tsx
+++ b/components/client/programs/graduate/graduate-program-summary.tsx
@@ -160,7 +160,7 @@ function GraduateProgramSummarySectionMap({ map, shouldCombine = true, showCombi
 
 function GraduateProgramDuration({ duration }: { duration: GraduateProgramDuration[] }) {
   const map = duration.reduce((acc, item) => {
-    const range = item.min ? `${item.min}-${item.max} months` : `${item.max} months`;
+    const range = item.max ? `${item.min}-${item.max} months` : `${item.min} months`;
     const value = `${toTitleCase(item.type)}: ${range}`;
 
     const existing = acc.get(item.programType?.name ?? "") ?? [];

--- a/components/client/programs/graduate/graduate-program-summary.tsx
+++ b/components/client/programs/graduate/graduate-program-summary.tsx
@@ -160,7 +160,7 @@ function GraduateProgramSummarySectionMap({ map, shouldCombine = true, showCombi
 
 function GraduateProgramDuration({ duration }: { duration: GraduateProgramDuration[] }) {
   const map = duration.reduce((acc, item) => {
-    const range = item.max ? `${item.min}-${item.max} months` : `${item.min} months`;
+    const range = item.max && (item.min < item.max) ? `${item.min}-${item.max} months` : `${item.min} months`;
     const value = `${toTitleCase(item.type)}: ${range}`;
 
     const existing = acc.get(item.programType?.name ?? "") ?? [];

--- a/data/drupal/graduate-program.ts
+++ b/data/drupal/graduate-program.ts
@@ -378,8 +378,8 @@ export function parseGraduateProgramVariant(variant: GraduateProgramVariantFragm
       if (!item.durationType) {
         duration.push({
           type: durationType,
-          min: item.durationMinimum ?? undefined,
-          max: item.durationMaximum,
+          min: item.durationMinimum,
+          max: item.durationMaximum ?? undefined,
         });
       }
 

--- a/lib/types/graduate-program-variant.ts
+++ b/lib/types/graduate-program-variant.ts
@@ -39,8 +39,8 @@ export type GraduateProgramApplicationDeadline = {
 
 export type GraduateProgramDuration = {
   type: string;
-  min?: number;
-  max: number;
+  min: number;
+  max?: number;
   programType?: GraduateProgramType;
 };
 


### PR DESCRIPTION
# Summary of changes
Update summary to use minimum duration value as required default instead of maximum

Before:
<img width="1433" height="395" alt="image" src="https://github.com/user-attachments/assets/cf2487f7-301e-4cd0-8a5d-5033a28eefd3" />

After:
<img width="1428" height="394" alt="image" src="https://github.com/user-attachments/assets/e65218da-4c11-4578-8bcb-15089f894964" />

## Frontend
Update summary to use minimum duration value as default

## Backend
- Changes have been applied to Live and committed to Dev

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. View https://deploy-preview-434--ugnext.netlify.app/miranda-testing
2. It should show 12 months instead of 12-null months when maximum is blank