### PR TITLE
Fix rendering of info boxes on Program pages

### DIFF
--- a/components/client/html-parser/instructions/font-awesome.tsx
+++ b/components/client/html-parser/instructions/font-awesome.tsx
@@ -28,12 +28,18 @@ export const FontAwesomeInstruction: HTMLParserInstruction = {
       (node.children?.length ?? 0) > 0 &&
       node.children.every((child) => child.type === "text" && (child as any).data?.trim() === "");
 
+    // Skip margin when inside a heading — the heading flex gap handles spacing instead
+    const headingTags = new Set(["h1", "h2", "h3", "h4", "h5", "h6"]);
+    const isInHeading =
+      headingTags.has((node.parent as any)?.tagName ?? "") ||
+      headingTags.has((node.parent as any)?.parent?.tagName ?? "");
+
     // Map legacy Bootstrap/custom color class names to Tailwind equivalents
     const colorClassMap: Record<string, string> = {
-      green: "text-green-600",
-      red: "text-red-600",
-      blue: "text-blue-600",
-      yellow: "text-yellow-500",
+      green: "text-green",
+      red: "text-red",
+      blue: "text-blue",
+      yellow: "text-yellow",
     };
     const remappedClassName = className
       .split(/\s+/)
@@ -43,8 +49,8 @@ export const FontAwesomeInstruction: HTMLParserInstruction = {
     const classes = twMerge(
       remappedClassName,
       className.includes("fs-1") && "sm:text-3xl p-0",
-      (hasInlineNextSibling || hasWhitespaceOnlyChildren) && "mr-[0.3em]",
-      hasInlinePreSibling && "ml-[0.3em]"
+      (hasInlineNextSibling || hasWhitespaceOnlyChildren) && !isInHeading && "mr-[0.3em]",
+      hasInlinePreSibling && !isInHeading && "ml-[0.3em]"
     );
 
     return (

--- a/components/client/html-parser/instructions/font-awesome.tsx
+++ b/components/client/html-parser/instructions/font-awesome.tsx
@@ -23,16 +23,33 @@ export const FontAwesomeInstruction: HTMLParserInstruction = {
     const hasInlinePreSibling =
       node.prev?.type === "text" || (node.prev?.type === ElementType.Tag && inlineTags.has(node.prev?.tagName));
 
+    // Detect CKEditor's &nbsp; spacing hack: whitespace-only children inside the icon
+    const hasWhitespaceOnlyChildren =
+      (node.children?.length ?? 0) > 0 &&
+      node.children.every((child) => child.type === "text" && (child as any).data?.trim() === "");
+
+    // Map legacy Bootstrap/custom color class names to Tailwind equivalents
+    const colorClassMap: Record<string, string> = {
+      green: "text-green-600",
+      red: "text-red-600",
+      blue: "text-blue-600",
+      yellow: "text-yellow-500",
+    };
+    const remappedClassName = className
+      .split(/\s+/)
+      .map((cls) => colorClassMap[cls] ?? cls)
+      .join(" ");
+
     const classes = twMerge(
-      props.className as string,
+      remappedClassName,
       className.includes("fs-1") && "sm:text-3xl p-0",
-      hasInlineNextSibling && "mr-[0.3em]",
+      (hasInlineNextSibling || hasWhitespaceOnlyChildren) && "mr-[0.3em]",
       hasInlinePreSibling && "ml-[0.3em]"
     );
 
     return (
       <i {...props} key={nanoid()} aria-hidden="true" className={classes}>
-        {children}
+        {hasWhitespaceOnlyChildren ? null : children}
       </i>
     );
   },

--- a/components/client/html-parser/instructions/heading.tsx
+++ b/components/client/html-parser/instructions/heading.tsx
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import React from "react";
 import { Typography } from "@uoguelph/react-components/typography";
 import { twMerge } from "tailwind-merge";
 import { clamp } from "@uoguelph/react-components";
@@ -24,6 +25,17 @@ export const HeadingInstruction: HTMLParserInstruction = {
     const headingClass = className.match(/\bh\d\b/g);
     const displayClass = /\bdisplay-(\d)\b/g.exec(className);
     const cleanedChildren = unwrapTags(children);
+
+    const isFAIconNode = (child: any) =>
+      child?.type === "tag" && child.tagName === "i" && /\b(fa[srlbdt]?|fa-[a-z0-9-]+)\b/.test(child.attribs?.class ?? "");
+    const firstMeaningfulDOMChild = node.children?.find(
+      (child) => !(child.type === "text" && (child as any).data?.trim() === "")
+    );
+    const startsWithIcon =
+      isFAIconNode(firstMeaningfulDOMChild) ||
+      ((firstMeaningfulDOMChild as any)?.tagName === "em" &&
+        (firstMeaningfulDOMChild as any)?.children?.some(isFAIconNode));
+
     let type = level;
     let emphasize = false;
 
@@ -48,7 +60,7 @@ export const HeadingInstruction: HTMLParserInstruction = {
         type={type}
         as={level}
         emphasize={emphasize}
-        className={twMerge("group-first/html-parser:first:mt-0", className)}
+        className={twMerge("group-first/html-parser:first:mt-0", startsWithIcon && "flex items-baseline gap-[0.4em]", className)}
       >
         {cleanedChildren}
       </Typography>

--- a/components/client/html-parser/instructions/row.tsx
+++ b/components/client/html-parser/instructions/row.tsx
@@ -17,7 +17,42 @@ export const RowInstruction: HTMLParserInstruction = {
 
     let convertedGrid: string[] = [];
 
-    {
+    // Check for row-cols-* classes on the row element itself first.
+    // e.g. "row-cols-1 row-cols-md-3" defines layout without per-child col classes.
+    const rowColsPattern = /^row-cols-(?:(xs|sm|md|lg|xl|xxl)-)?(\d+)$/;
+    const rowClasses = (props.className as string).split(/\s+/);
+    let hasRowCols = false;
+
+    rowClasses.forEach((cls) => {
+      const match = cls.match(rowColsPattern);
+      if (match) {
+        hasRowCols = true;
+        const viewport = match[1];
+        const numCols = parseInt(match[2]);
+        const gridCols = Array(numCols).fill("1fr");
+
+        if (!viewport) {
+          templateValues.base = gridCols;
+        } else {
+          switch (viewport) {
+            case "xs":
+            case "sm":
+              templateValues.sm = gridCols;
+              break;
+            case "md":
+            case "lg":
+              templateValues.md = gridCols;
+              break;
+            case "xl":
+            case "xxl":
+              templateValues.xl = gridCols;
+              break;
+          }
+        }
+      }
+    });
+
+    if (!hasRowCols) {
       React.Children.map(children, (child) => {
         // Parse divs with Boostrap column classes
         if (typeof child !== "string" && child.type === "div") {

--- a/components/client/html-parser/instructions/row.tsx
+++ b/components/client/html-parser/instructions/row.tsx
@@ -58,8 +58,6 @@ export const RowInstruction: HTMLParserInstruction = {
         if (typeof child !== "string" && child.type === "div") {
           let bsClasses = child.props.className;
 
-          // console.log("Converting:" + bsClasses);
-
           // Assumes Bootstrap format can be col, col-6, col-md, or col-md-6
           if (bsClasses?.includes("col")) {
             let bsColumnClasses: string[] = bsClasses.split(" ");
@@ -76,10 +74,10 @@ export const RowInstruction: HTMLParserInstruction = {
                 // Convert bootstrap columns
                 switch (bootstrapNumColumns[0]) {
                   case "3":
-                    convertedGrid = ["1fr", "1fr", "1fr"];
+                    convertedGrid = ["1fr", "1fr", "1fr", "1fr"];
                     break;
                   case "4":
-                    convertedGrid = ["1fr", "1fr", "1fr", "1fr"];
+                    convertedGrid = ["1fr", "1fr", "1fr"];
                     break;
                   case "6":
                     convertedGrid = ["1fr", "1fr"];
@@ -124,10 +122,8 @@ export const RowInstruction: HTMLParserInstruction = {
       }
     });
 
-    // console.log(templateValues);
-
     return (
-      <Grid className="gap-4 pb-4" template={templateValues}>
+      <Grid className="gap-4 py-4" template={templateValues}>
         {children}
       </Grid>
     );


### PR DESCRIPTION
# Summary of changes
- Fixes parsing and rendering of Bootstrap classes for displaying info boxes on programs (the ones with green checkmarks)
- Fixes #286

## Frontend

This pull request improves the HTML parser instructions for FontAwesome icons, headings, and Bootstrap-style rows to better handle legacy markup and edge cases. The main enhancements include improved spacing logic for icons, better detection and layout for heading icons, and more robust parsing of Bootstrap grid classes.

**FontAwesome icon rendering improvements:**
- Added logic to detect and skip whitespace-only children (such as CKEditor's `&nbsp;` hack) inside icons, preventing unwanted rendering and spacing issues.
- Updated margin application so that icons inside headings do not receive extra spacing; spacing is now handled by the heading's flex gap.
- Implemented a mapping from legacy Bootstrap/custom color classes (e.g., `green`, `red`) to Tailwind equivalents for consistent styling.

**Heading instruction enhancements:**
- Improved detection of FontAwesome icons at the start of headings, including cases where the icon is wrapped in an `<em>` tag. If a heading starts with an icon, a flex layout with baseline alignment and a gap is applied for better visual alignment. [[1]](diffhunk://#diff-74e70bf4e7e2b36cfbf2eb7ea395351e0f0256fdefbea39362e81ec3aa50138eR28-R38) [[2]](diffhunk://#diff-74e70bf4e7e2b36cfbf2eb7ea395351e0f0256fdefbea39362e81ec3aa50138eL51-R63)

**Bootstrap row/grid parsing fixes:**
- Enhanced the `RowInstruction` to support `row-cols-*` classes directly on the row element, mapping them to responsive CSS grid templates. Falls back to per-child column class parsing if not present.
- Fixed a bug in the mapping of Bootstrap column numbers to grid templates: now `col-3` yields four columns and `col-4` yields three, matching the expected layout.
- Changed the grid container's padding from `pb-4` (padding-bottom) to `py-4` (vertical padding) for more consistent spacing.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger

# Test Plan

Review the following pages and verify they display as expected in both narrow and wide viewports:

- https://deploy-preview-435--ugnext.netlify.app/programs/microbiology-immunology (3 boxes with 1-line headings)
- https://deploy-preview-435--ugnext.netlify.app/programs/zoology (2 boxes)
- https://deploy-preview-435--ugnext.netlify.app/programs/theoretical-physics (3 boxes, mix of 1 and 2-line headings)
- https://deploy-preview-435--ugnext.netlify.app/programs/food-agricultural-resource-economics (3 boxes, mix of 1 and 2-line headings)
- https://deploy-preview-435--ugnext.netlify.app/programs/family-studies-and-human-development (3 boxes with 2-line headings)
- https://deploy-preview-435--ugnext.netlify.app/program-layout-test (6 boxes - this is a clone of the unpublished Bachelor of One Health basic page)

You can also review additional programs from https://deploy-preview-435--ugnext.netlify.app/programs/undergraduate
