### PR TITLE
Use slugified accordion item title as the ID value

### DIFF
--- a/components/client/widgets/accordions.tsx
+++ b/components/client/widgets/accordions.tsx
@@ -24,7 +24,7 @@ export function AccordionWidget({ data }: { data: AccordionFragment }) {
       {description && <HtmlParser html={description} />}
 
       {data?.items.map((item, index) => (
-        <Accordion id={`accordion-${item.uuid}`} key={index}>
+        <Accordion id={slugify(item.accordionTitle)} key={index}>
           <AccordionButton>{item.accordionTitle}</AccordionButton>
           <AccordionContent>
             <HtmlParser html={item.text.processed} />


### PR DESCRIPTION
# Summary of changes
Make accordion IDs simpler and more user-friendly so content editors can use them in anchor links without having to dig through the browser inspector first

## Frontend

This pull request introduces a small change to the `AccordionWidget` component to improve the accessibility and consistency of the rendered accordion elements. Instead of using the array index for the `Accordion`'s `id` prop, it now uses a slugified version of the `accordionTitle`. 

This helps ensure unique and descriptive IDs for each accordion section.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

- Go to https://deploy-preview-442--ugnext.netlify.app/programs/master-of-applied-nutrition
- Verify that the accordion items (they will be divs) have the slugified versions of their titles as IDs
- Verify the IDs work as anchor links, e.g. https://deploy-preview-442--ugnext.netlify.app/programs/master-of-applied-nutrition#admission-requirements