### PR TITLE
Check APP_ENV in addition to NODE_ENV

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function Page({ params }: Props) {
       permanentRedirect("/programs/undergraduate/requirements/");
       break;
     default:
-      if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
+      if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
         console.warn(
           `Attempted to render a page with an entity type ${route.entity.__typename} but no component is set to render that type in app/[...slug]/page.tsx.`
         );

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function Page({ params }: Props) {
       permanentRedirect("/programs/undergraduate/requirements/");
       break;
     default:
-      if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
+      if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
         console.warn(
           `Attempted to render a page with an entity type ${route.entity.__typename} but no component is set to render that type in app/[...slug]/page.tsx.`
         );

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -93,7 +93,7 @@ export default async function Page({ params }: Props) {
       permanentRedirect("/programs/undergraduate/requirements/");
       break;
     default:
-      if (process.env.NODE_ENV === "development") {
+      if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
         console.warn(
           `Attempted to render a page with an entity type ${route.entity.__typename} but no component is set to render that type in app/[...slug]/page.tsx.`
         );

--- a/app/api/aad-profile/route.ts
+++ b/app/api/aad-profile/route.ts
@@ -767,7 +767,7 @@ export async function OPTIONS(req: NextRequest) {
   const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || defaultOrigins;
   
   // Never allow wildcard in production
-  if ((process.env.NODE_ENV === 'production' || process.env.APP_ENV === "live") && allowedOrigins.includes('*')) {
+  if ((process.env.NODE_ENV === "production" || process.env.APP_ENV === "live") && allowedOrigins.includes('*')) {
     console.error('CORS wildcard (*) not allowed in production. Set ALLOWED_ORIGINS environment variable.');
     return new NextResponse(JSON.stringify({ error: 'CORS misconfiguration' }), {
       status: 500,

--- a/app/api/aad-profile/route.ts
+++ b/app/api/aad-profile/route.ts
@@ -760,7 +760,7 @@ export async function OPTIONS(req: NextRequest) {
   const origin = req.headers.get('origin');
   
   // Default to localhost for development, require explicit configuration for production
-  const defaultOrigins = process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live" 
+  const defaultOrigins = process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" 
     ? ['http://localhost:3000', 'http://localhost:3001']
     : [];
   

--- a/app/api/aad-profile/route.ts
+++ b/app/api/aad-profile/route.ts
@@ -760,14 +760,14 @@ export async function OPTIONS(req: NextRequest) {
   const origin = req.headers.get('origin');
   
   // Default to localhost for development, require explicit configuration for production
-  const defaultOrigins = process.env.NODE_ENV === 'development' 
+  const defaultOrigins = process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" 
     ? ['http://localhost:3000', 'http://localhost:3001']
     : [];
   
   const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || defaultOrigins;
   
   // Never allow wildcard in production
-  if (process.env.NODE_ENV === 'production' && allowedOrigins.includes('*')) {
+  if ((process.env.NODE_ENV === 'production' || process.env.APP_ENV === "live") && allowedOrigins.includes('*')) {
     console.error('CORS wildcard (*) not allowed in production. Set ALLOWED_ORIGINS environment variable.');
     return new NextResponse(JSON.stringify({ error: 'CORS misconfiguration' }), {
       status: 500,

--- a/app/api/aad-profile/route.ts
+++ b/app/api/aad-profile/route.ts
@@ -760,7 +760,7 @@ export async function OPTIONS(req: NextRequest) {
   const origin = req.headers.get('origin');
   
   // Default to localhost for development, require explicit configuration for production
-  const defaultOrigins = process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" 
+  const defaultOrigins = process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live" 
     ? ['http://localhost:3000', 'http://localhost:3001']
     : [];
   

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -28,7 +28,7 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
   },
-  debug: process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live",
+  debug: process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live",
 }
 
 const handler = NextAuth(authOptions)

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -28,7 +28,7 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
   },
-  debug: process.env.NODE_ENV === 'development',
+  debug: process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live",
 }
 
 const handler = NextAuth(authOptions)

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -28,7 +28,7 @@ export const authOptions: AuthOptions = {
   session: {
     strategy: 'jwt',
   },
-  debug: process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live",
+  debug: process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live",
 }
 
 const handler = NextAuth(authOptions)

--- a/app/api/draft/route.ts
+++ b/app/api/draft/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest): Promise<Response | never> {
 
   // Manually enter draft mode if provided DRUPAL_PREVIEW_SECRET directly in the URL and in development mode.
   // This is useful for testing draft mode locally.
-  if (secret === process.env.DRUPAL_PREVIEW_SECRET && process.env.NODE_ENV !== "production" && process.env.APP_ENV !== "live") {
+  if (secret === process.env.DRUPAL_PREVIEW_SECRET && (process.env.NODE_ENV !== "production" || process.env.APP_ENV !== "live")) {
     if (!path) {
       return NextResponse.json(
         {

--- a/app/api/draft/route.ts
+++ b/app/api/draft/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest): Promise<Response | never> {
 
   // Manually enter draft mode if provided DRUPAL_PREVIEW_SECRET directly in the URL and in development mode.
   // This is useful for testing draft mode locally.
-  if (secret === process.env.DRUPAL_PREVIEW_SECRET && process.env.NODE_ENV !== "production") {
+  if (secret === process.env.DRUPAL_PREVIEW_SECRET && process.env.NODE_ENV !== "production" && process.env.APP_ENV !== "live") {
     if (!path) {
       return NextResponse.json(
         {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const gtmId =
-    process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
+    process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
   const { isEnabled: isDraftMode } = await draftMode();
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const gtmId =
-    process.env.NODE_ENV === "development" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
+    process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
   const { isEnabled: isDraftMode } = await draftMode();
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const gtmId =
-    process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
+    process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
   const { isEnabled: isDraftMode } = await draftMode();
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const gtmId =
-    process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
+    process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
   const { isEnabled: isDraftMode } = await draftMode();
 
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const gtmId =
-    process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
+    process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live" ? process.env.NEXT_PUBLIC_GTM_ID_DEV : process.env.NEXT_PUBLIC_GTM_ID;
   const { isEnabled: isDraftMode } = await draftMode();
 
   return (

--- a/components/server/basic-page.tsx
+++ b/components/server/basic-page.tsx
@@ -78,7 +78,7 @@ export async function BasicPage({ id, pre, post }: BasicPageProps) {
 
   // Couldn't fetch content for this id.
   if (!page) {
-    if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
+    if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
       console.warn(`Couldn't find content for basic page with id ${id}`);
 
       if (process.env.ALWAYS_SHOW_PUBLISHED_CONTENT) {

--- a/components/server/basic-page.tsx
+++ b/components/server/basic-page.tsx
@@ -78,7 +78,7 @@ export async function BasicPage({ id, pre, post }: BasicPageProps) {
 
   // Couldn't fetch content for this id.
   if (!page) {
-    if (process.env.NODE_ENV === "development") {
+    if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
       console.warn(`Couldn't find content for basic page with id ${id}`);
 
       if (process.env.ALWAYS_SHOW_PUBLISHED_CONTENT) {

--- a/components/server/basic-page.tsx
+++ b/components/server/basic-page.tsx
@@ -78,7 +78,7 @@ export async function BasicPage({ id, pre, post }: BasicPageProps) {
 
   // Couldn't fetch content for this id.
   if (!page) {
-    if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
+    if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
       console.warn(`Couldn't find content for basic page with id ${id}`);
 
       if (process.env.ALWAYS_SHOW_PUBLISHED_CONTENT) {

--- a/components/server/profile.tsx
+++ b/components/server/profile.tsx
@@ -41,7 +41,7 @@ export async function Profile({ id, pre, post }: ProfileProps) {
 
   // Couldn't fetch content for this id.
   if (!content) {
-    if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
+    if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
       console.warn(`Couldn't find content for profile with id ${id}`);
 
       if (process.env.ALWAYS_SHOW_PUBLISHED_CONTENT) {

--- a/components/server/profile.tsx
+++ b/components/server/profile.tsx
@@ -41,7 +41,7 @@ export async function Profile({ id, pre, post }: ProfileProps) {
 
   // Couldn't fetch content for this id.
   if (!content) {
-    if (process.env.NODE_ENV === "development") {
+    if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
       console.warn(`Couldn't find content for profile with id ${id}`);
 
       if (process.env.ALWAYS_SHOW_PUBLISHED_CONTENT) {

--- a/components/server/profile.tsx
+++ b/components/server/profile.tsx
@@ -41,7 +41,7 @@ export async function Profile({ id, pre, post }: ProfileProps) {
 
   // Couldn't fetch content for this id.
   if (!content) {
-    if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
+    if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
       console.warn(`Couldn't find content for profile with id ${id}`);
 
       if (process.env.ALWAYS_SHOW_PUBLISHED_CONTENT) {

--- a/lib/drupal.ts
+++ b/lib/drupal.ts
@@ -10,5 +10,5 @@ export const drupal = new NextDrupal(baseUrl, {
     clientSecret,
   },
   withAuth: true,
-  debug: process.env.NODE_ENV === "development",
+  debug: process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live",
 });

--- a/lib/drupal.ts
+++ b/lib/drupal.ts
@@ -10,5 +10,5 @@ export const drupal = new NextDrupal(baseUrl, {
     clientSecret,
   },
   withAuth: true,
-  debug: process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live",
+  debug: process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live",
 });

--- a/lib/drupal.ts
+++ b/lib/drupal.ts
@@ -10,5 +10,5 @@ export const drupal = new NextDrupal(baseUrl, {
     clientSecret,
   },
   withAuth: true,
-  debug: process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live",
+  debug: process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live",
 });

--- a/lib/show-unpublished-content.ts
+++ b/lib/show-unpublished-content.ts
@@ -13,7 +13,7 @@ export async function showUnpublishedContent() {
     return null;
   }
 
-  if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
+  if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
     return true;
   }
 

--- a/lib/show-unpublished-content.ts
+++ b/lib/show-unpublished-content.ts
@@ -13,7 +13,7 @@ export async function showUnpublishedContent() {
     return null;
   }
 
-  if (process.env.NODE_ENV === "development" || process.env.APP_ENV !== "live") {
+  if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
     return true;
   }
 

--- a/lib/show-unpublished-content.ts
+++ b/lib/show-unpublished-content.ts
@@ -13,7 +13,7 @@ export async function showUnpublishedContent() {
     return null;
   }
 
-  if (process.env.NODE_ENV === "development") {
+  if (process.env.NODE_ENV === "development" && process.env.APP_ENV !== "live") {
     return true;
   }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -123,6 +123,7 @@ function getNextConfig(): NextConfig {
       "cache",
       "cache-handler.mjs"
     );
+    config.cacheMaxMemorySize = 0; // Disable in-memory caching to use custom handler
     // For cache components
     /*
     config.cacheComponents = true;

--- a/next.config.ts
+++ b/next.config.ts
@@ -123,7 +123,7 @@ function getNextConfig(): NextConfig {
       "cache",
       "cache-handler.mjs"
     );
-    config.cacheMaxMemorySize = 0; // Disable in-memory caching to use custom handler
+    // config.cacheMaxMemorySize = 0; // Disable in-memory caching to use custom handler
     // For cache components
     /*
     config.cacheComponents = true;


### PR DESCRIPTION
# Summary of changes
- Check APP_ENV in addition to NODE_ENV
- This ensures that the GTM id uses the dev ID for development environments and the production ID for production

## Frontend
- Check APP_ENV in addition to NODE_ENV
- This ensures that the GTM id uses the dev ID for development environments and the production ID for production

## Backend
- None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [n/a] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Go to the homepage and confirm if the development GTM ID is showing instead of the production GTM ID: https://pr-443-ugnext01.pantheonsite.io/ and on the deploy preview https://deploy-preview-443--ugnext.netlify.app
2. Check environment variables