### PR TITLE
Update Docker configuration for regenerating visual regression snapshots

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,16 @@ WORKDIR /workspace
 ARG FONTAWESOME_PACKAGE_TOKEN
 ENV FONTAWESOME_PACKAGE_TOKEN=$FONTAWESOME_PACKAGE_TOKEN
 
+# Copy the entrypoint into the image
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Copy the dependency manifests so the image still builds successfully
 COPY package.json bun.lock bunfig.toml ./
 
-RUN bun install --frozen-lockfile
-
+# Copy the rest of the project
 COPY . .
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["bun", "run", "test:update-snapshots"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,27 @@ services:
       dockerfile: Dockerfile
       args:
         FONTAWESOME_PACKAGE_TOKEN: ${FONTAWESOME_PACKAGE_TOKEN}
+
     working_dir: /workspace
     ipc: host
+
     volumes:
       - .:/workspace
       - node_modules:/workspace/node_modules
       - next_cache:/workspace/.next
       - ./test-results:/workspace/test-results
       - ./playwright-report:/workspace/playwright-report
+
     env_file:
       - .env
+
     environment:
       HOME: /tmp
       CI: "true"
       USE_TESTING_DATA: "true"
+
     command: ["bun", "run", "test:update-snapshots"]
+
+volumes:
+  node_modules:
+  next_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     ipc: host
     volumes:
       - .:/workspace
-      - /workspace/node_modules
-      - /workspace/.next
+      - node_modules:/workspace/node_modules
+      - next_cache:/workspace/.next
       - ./test-results:/workspace/test-results
       - ./playwright-report:/workspace/playwright-report
     env_file:
@@ -19,4 +19,4 @@ services:
       HOME: /tmp
       CI: "true"
       USE_TESTING_DATA: "true"
-    command: sh -c "bun run build && bunx playwright test --update-snapshots"
+    command: ["bun", "run", "test:update-snapshots"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+bun install --frozen-lockfile
+
+exec "$@"

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "export": "next build && next export",
     "format": "prettier -w ./",
     "test": "bun run build && bunx playwright test",
-    "test:update-snapshots": "next build && bunx playwright test --update-snapshots",
-    "docker:test:update-snapshots": "docker compose run --rm playwright-update-snapshots",
+    "test:update-snapshots": "bun run build && bunx playwright test --update-snapshots",
+    "docker:test:update-snapshots": "docker compose run --rm playwright-update-snapshots bun run test:update-snapshots",
     "docker:clean": "docker compose down -v",
     "codegen:compile": "graphql-codegen",
     "codegen:watch": "graphql-codegen -w"


### PR DESCRIPTION
# Summary of changes
Making the docker regeneration of playwright snapshots simpler.

## Frontend
- Automatically update dependencies when command is run
- Allow .next and node-modules volumes to persist


## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [x] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Install Docker Desktop: https://www.docker.com/products/docker-desktop/
2. Start Docker Desktop
3. Run `bun run docker:test:update-snapshots`
4. Ensure command runs successfully.