### PR TITLE
Add tag-based URL filter for Undergraduate Program Search

### DIFF
--- a/components/client/programs/program-search.tsx
+++ b/components/client/programs/program-search.tsx
@@ -9,6 +9,7 @@ import { Container } from "@uoguelph/react-components/container";
 import { Select, SelectOptions, SelectButton, SelectOption } from "@uoguelph/react-components/select";
 import type { UndergraduateProgram, UndergraduateProgramType } from "@/data/drupal/undergraduate-program";
 import type { UndergraduateDegree, UndergraduateDegreeType } from "@/data/drupal/undergraduate-degree";
+import { useSearchParams } from "next/navigation";
 
 // PHASE 1 - YAML-BASED (Graduate) - also update /apps/programs/graduate/page
 // To be commented out during Phase 2
@@ -61,6 +62,8 @@ type ProgramSearchProps = {
 export const ProgramSearch = ({ programs, types, degreeTypes, useDegreeAcronym = false }: ProgramSearchProps) => {
   const [input, setInput] = useState("");
   const [selectedTypes, setSelectedTypes] = useState<ProgramType[]>(types);
+  const searchParams = useSearchParams();
+  const searchTags = searchParams.getAll('tags') 
 
   // The fuzzy search function
   const search = useFuzzySearch({
@@ -92,6 +95,14 @@ export const ProgramSearch = ({ programs, types, degreeTypes, useDegreeAcronym =
   }, [input, programs, search]);
 
   const filtered = useMemo(() => {
+    if (Array.isArray(searchTags) && searchTags.length > 0) {
+      return fuzzyMatches.filter((program) => {
+        if(Array.isArray(program.tags)) {
+          return program.tags.some((tag) => searchTags.some((t) => t === tag));
+        }
+      })
+    }
+
     if (selectedTypes.length === 0) return fuzzyMatches;
 
     return fuzzyMatches.filter((program) => {


### PR DESCRIPTION
# Summary of changes
Add tag-based URL filter for Undergraduate Program Search

## Frontend
Add tag-based URL filter for Undergraduate Program Search

## Backend
None

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

1. Visit the https://pr-448-ugnext01.pantheonsite.io/programs/undergraduate search
2. You should see all programs
3. Visit https://pr-448-ugnext01.pantheonsite.io/programs/undergraduate?tags=software%20engineering
4. You should see programs that have been tagged with software engineering
3. Visit https://pr-448-ugnext01.pantheonsite.io/programs/undergraduate?tags=software%20engineering&tags=business
4. You should see programs that have been tagged with software engineering AND programs that have been tagged with business (i.e., if a program only has business and not software engineering in its tags, it will still show)
5. Visit https://pr-448-ugnext01.pantheonsite.io/programs/undergraduate?tags=this-does-not-exist
6. There should be no programs showing because the tag does not exist
7. Visit https://pr-448-ugnext01.pantheonsite.io/programs/undergraduate?tags=this-does-not-exist&tags=business
8. Even though the one tag does not exist, the other tag business does exist, so you should see programs associated with business