### PR TITLE
Enhance image source handling for Next.js format

### DIFF
--- a/components/client/html-parser/instructions/image.tsx
+++ b/components/client/html-parser/instructions/image.tsx
@@ -18,8 +18,12 @@ export const ImageInstruction: HTMLParserInstruction = {
 
     if (src.startsWith("/sites/default/files")) {
       src = `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}${props.src}`;
-    } else if (src.startsWith("/.netlify/images?url=")) {
-      src = src.replace("/.netlify/images?url=", "");
+    } else if (src.startsWith("/_next/image?url=")) {
+      // Next.js optimizer format: /_next/image?url=<encoded>&w=...&q=...
+      const encodedUrl = src.match(/[?&]url=([^&]+)/)?.[1];
+      if (encodedUrl) {
+        src = decodeURIComponent(encodedUrl);
+      }
     }
 
     const ImageComponent = props.width && props.height ? Image : "img";

--- a/components/client/html-parser/instructions/image.tsx
+++ b/components/client/html-parser/instructions/image.tsx
@@ -17,13 +17,10 @@ export const ImageInstruction: HTMLParserInstruction = {
     let src = props.src as string;
 
     if (src.startsWith("/sites/default/files")) {
-      src = `${process.env.NEXT_PUBLIC_DRUPAL_BASE_URL}${props.src}`;
-    } else if (src.startsWith("/_next/image?url=")) {
-      // Next.js optimizer format: /_next/image?url=<encoded>&w=...&q=...
-      const encodedUrl = src.match(/[?&]url=([^&]+)/)?.[1];
-      if (encodedUrl) {
-        src = decodeURIComponent(encodedUrl);
-      }
+      src = new URL(
+        src,
+        process.env.NEXT_PUBLIC_DRUPAL_BASE_URL
+      ).toString();
     }
 
     const ImageComponent = props.width && props.height ? Image : "img";


### PR DESCRIPTION
# Summary of changes
Fix broken inline image src links on the Pantheon Next.js build

## Frontend

This pull request updates the logic for constructing image URLs in the `ImageInstruction` HTML parser instruction. The change improves how relative image paths are converted to absolute URLs, ensuring better compatibility and correctness.

**Image URL handling improvements:**

* Updated the logic for handling image sources that start with `/sites/default/files` by using the `URL` constructor to combine the base URL and relative path, ensuring proper URL formatting.
* Removed the special-case handling for image sources starting with `/.netlify/images?url=`, simplifying the code and eliminating unnecessary string manipulation.

## Backend
N/A

## Checklist

- [x] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [x] My changes are responsive and appear as expected on mobile and desktop views.
- [x] My changes have been reviewed to ensure they do not break an existing analytics trigger

# Test Plan

Go to https://pr-449-ugnext01.pantheonsite.io/webtests/logo-test and verify the Virtual Sponsor logos load correctly