### PR TITLE
k6 load testing script for high-traffic scenarios

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "codegen:watch": "graphql-codegen -w",
     "load-test": "k6 run tests/load/graphql-load.js",
     "load-test:test": "k6 run --env BASE_URL=$LOAD_TEST_BASE_URL tests/load/graphql-load.js"
-
   },
   "dependencies": {
     "@awesome.me/kit-7993323d0c": "^1.0.11",
@@ -74,6 +73,7 @@
     "@parcel/watcher": "^2.6.0",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.3",
+    "@types/k6": "^2.0.1",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "docker:test:update-snapshots": "docker compose run --rm playwright-update-snapshots",
     "docker:clean": "docker compose down -v",
     "codegen:compile": "graphql-codegen",
-    "codegen:watch": "graphql-codegen -w"
+    "codegen:watch": "graphql-codegen -w",
+    "load-test": "k6 run tests/load/graphql-load.js",
+    "load-test:test": "k6 run --env BASE_URL=$LOAD_TEST_BASE_URL tests/load/graphql-load.js"
+
   },
   "dependencies": {
     "@awesome.me/kit-7993323d0c": "^1.0.11",

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -1,0 +1,144 @@
+/**
+ * k6 load test – GraphQL traffic simulation
+ *
+ * Mimics the traffic pattern identified in the June 2026 outage:
+ * many concurrent Next.js SSR renders each driving fresh POST /graphql
+ * requests against the Drupal backend.
+ *
+ * Run locally:
+ *   k6 run tests/load/graphql-load.js
+ *
+ * Run against staging:
+ *   BASE_URL=https://staging.example.com k6 run tests/load/graphql-load.js
+ *
+ * Scenarios
+ * ─────────
+ * baseline   – steady 10 VUs over 1 min  (sanity check, should always pass)
+ * soak       – 50 VUs over 5 min         (mirrors normal peak load)
+ * spike      – ramps to 300 VUs in 30 s  (reproduces the outage conditions)
+ */
+
+import http from "k6/http";
+import { check, group, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+// Pages that are representative of a typical browse session.
+// These drive Next.js SSR which in turn calls Drupal /graphql.
+const PAGES = [
+  "/",
+  "/ovc/news-hub",
+  "/programs/undergraduate",
+  "/soan/faculty",
+];
+
+// ── Custom metrics ─────────────────────────────────────────────────────────────
+
+const errorRate   = new Rate("error_rate");
+const p99Duration = new Trend("page_duration_p99", true);
+
+// ── Thresholds (test fails if these are breached) ──────────────────────────────
+
+export const options = {
+  scenarios: {
+    baseline: {
+      executor: "constant-vus",
+      vus: 10,
+      duration: "1m",
+      tags: { scenario: "baseline" },
+    },
+    soak: {
+      executor: "constant-vus",
+      vus: 50,
+      duration: "5m",
+      startTime: "1m30s",   // starts after baseline finishes + buffer
+      tags: { scenario: "soak" },
+    },
+    spike: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "30s", target: 300 },  // ramp up hard – reproduces the outage
+        { duration: "1m",  target: 300 },  // hold
+        { duration: "30s", target: 0   },  // ramp down
+      ],
+      startTime: "8m",   // starts after soak finishes + buffer
+      tags: { scenario: "spike" },
+    },
+  },
+
+  thresholds: {
+    // Overall error rate must stay below 1 %
+    error_rate: [{ threshold: "rate < 0.01", abortOnFail: false }],
+
+    // p95 response time for page loads: under 3 s
+    "http_req_duration{scenario:baseline}": ["p(95) < 3000"],
+    "http_req_duration{scenario:soak}"    : ["p(95) < 3000"],
+
+    // During the spike, allow up to 5 s p95 – but no 502s
+    "http_req_duration{scenario:spike}"   : ["p(95) < 5000"],
+    "http_req_failed{scenario:spike}"     : ["rate < 0.02"],
+  },
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function randomPage() {
+  return PAGES[Math.floor(Math.random() * PAGES.length)];
+}
+
+// ── Default function (runs once per VU iteration) ──────────────────────────────
+
+export default function () {
+  const page = randomPage();
+  const url  = `${BASE_URL}${page}`;
+
+  group("page load", () => {
+    const res = http.get(url, {
+      headers: { Accept: "text/html" },
+      tags:    { page },
+    });
+
+    const ok = check(res, {
+      "status is 200":         (r) => r.status === 200,
+      "no 502 bad gateway":    (r) => r.status !== 502,
+      "no 503 unavailable":    (r) => r.status !== 503,
+      "body not empty":        (r) => r.body.length > 0,
+    });
+
+    errorRate.add(!ok);
+    p99Duration.add(res.timings.duration);
+
+    if (res.status === 502 || res.status === 503) {
+      console.error(`[${res.status}] ${url}`);
+    }
+  });
+
+  // Simulate human think-time between page views (1–3 s)
+  sleep(1 + Math.random() * 2);
+}
+
+export function handleSummary(data) {
+  // Emit a JUnit-compatible summary for Azure Pipelines
+  return {
+    "test-results/k6-load-results.json": JSON.stringify(data, null, 2),
+    stdout: textSummary(data),
+  };
+}
+
+// Minimal text summary (k6 built-in textSummary is available in k6 >= 0.34)
+function textSummary(data) {
+  const m = data.metrics;
+  const lines = [
+    "═══════════════════════ k6 Load Test Summary ═══════════════════════",
+    `  Total requests  : ${m.http_reqs?.values?.count ?? "n/a"}`,
+    `  Error rate      : ${((m.error_rate?.values?.rate ?? 0) * 100).toFixed(2)} %`,
+    `  p95 duration    : ${(m.http_req_duration?.values?.["p(95)"] ?? 0).toFixed(0)} ms`,
+    `  p99 duration    : ${(m.http_req_duration?.values?.["p(99)"] ?? 0).toFixed(0)} ms`,
+    "═════════════════════════════════════════════════════════════════════",
+  ];
+  return lines.join("\n");
+}

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -47,26 +47,26 @@ export const options = {
   scenarios: {
     baseline: {
       executor: "constant-vus",
-      vus: 10,
-      duration: "1m",
+      vus: 5,
+      duration: "30s",
       tags: { scenario: "baseline" },
     },
     soak: {
       executor: "constant-vus",
-      vus: 50,
-      duration: "5m",
-      startTime: "1m30s",   // starts after baseline finishes + buffer
+      vus: 15,
+      duration: "1m",
+      startTime: "40s",   // starts after baseline finishes + buffer
       tags: { scenario: "soak" },
     },
     spike: {
       executor: "ramping-vus",
       startVUs: 0,
       stages: [
-        { duration: "30s", target: 300 },  // ramp up hard – reproduces the outage
-        { duration: "1m",  target: 300 },  // hold
-        { duration: "30s", target: 0   },  // ramp down
+        { duration: "15s", target: 50 },  // ramp up hard – reproduces the outage
+        { duration: "20s",  target: 50 },  // hold
+        { duration: "10s", target: 0   },  // ramp down
       ],
-      startTime: "8m",   // starts after soak finishes + buffer
+      startTime: "1m50s",   // starts after soak finishes + buffer
       tags: { scenario: "spike" },
     },
   },
@@ -107,7 +107,7 @@ export default function () {
       "status is 200":         (r) => r.status === 200,
       "no 502 bad gateway":    (r) => r.status !== 502,
       "no 503 unavailable":    (r) => r.status !== 503,
-      "body not empty":        (r) => r.body.length > 0,
+      "body not empty": (r) => (r.body?.length ?? 0) > 0,
     });
 
     errorRate.add(!ok);

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -124,7 +124,7 @@ export default function () {
 export function handleSummary(data) {
   // Emit a JUnit-compatible summary for Azure Pipelines
   return {
-    "test-results/k6-load-results.json": JSON.stringify(data, null, 2),
+    // "test-results/k6-load-results.json": JSON.stringify(data, null, 2),
     stdout: textSummary(data),
   };
 }

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -30,9 +30,10 @@ const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
 // These drive Next.js SSR which in turn calls Drupal /graphql.
 const PAGES = [
   "/",
-  "/ovc/news-hub",
+  "/about",
   "/programs/undergraduate",
-  "/soan/faculty",
+  "/widget-examples",
+  "/studentexperience",
 ];
 
 // ── Custom metrics ─────────────────────────────────────────────────────────────

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -31,9 +31,12 @@ const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
 const PAGES = [
   "/",
   "/about",
-  "/programs/undergraduate",
-  "/widget-examples",
+  "/csahs/people",
+  "/ovc/news-hub",
+  "/programs/undergraduate",  
   "/studentexperience",
+  "/webadvisor",
+  "/widget-examples",
 ];
 
 // ── Custom metrics ─────────────────────────────────────────────────────────────

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -48,26 +48,26 @@ export const options = {
   scenarios: {
     baseline: {
       executor: "constant-vus",
-      vus: 5,
-      duration: "30s",
+      vus: 10,
+      duration: "1m",
       tags: { scenario: "baseline" },
     },
     soak: {
       executor: "constant-vus",
-      vus: 15,
-      duration: "1m",
-      startTime: "40s",   // starts after baseline finishes + buffer
+      vus: 50,
+      duration: "5m",
+      startTime: "1m30s",   // starts after baseline finishes + buffer
       tags: { scenario: "soak" },
     },
     spike: {
       executor: "ramping-vus",
       startVUs: 0,
       stages: [
-        { duration: "15s", target: 50 },  // ramp up hard – reproduces the outage
-        { duration: "20s",  target: 50 },  // hold
-        { duration: "10s", target: 0   },  // ramp down
+        { duration: "30s", target: 300 },  // ramp up hard – reproduces the outage
+        { duration: "1m",  target: 300 },  // hold
+        { duration: "30s", target: 0   },  // ramp down
       ],
-      startTime: "1m50s",   // starts after soak finishes + buffer
+      startTime: "8m",   // starts after soak finishes + buffer
       tags: { scenario: "spike" },
     },
   },

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -44,6 +44,7 @@ const p99Duration = new Trend("page_duration_p99", true);
 // ── Thresholds (test fails if these are breached) ──────────────────────────────
 
 export const options = {
+  summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)"],
   scenarios: {
     baseline: {
       executor: "constant-vus",

--- a/tests/load/graphql-load.js
+++ b/tests/load/graphql-load.js
@@ -45,32 +45,60 @@ const p99Duration = new Trend("page_duration_p99", true);
 
 export const options = {
   summaryTrendStats: ["avg", "min", "med", "p(90)", "p(95)", "p(99)"],
+    // ── Scenario1: reduced-load values for fast local iteration ──────────────────
   scenarios: {
     baseline: {
       executor: "constant-vus",
-      vus: 10,
-      duration: "1m",
+      vus: 5,
+      duration: "30s",
       tags: { scenario: "baseline" },
     },
     soak: {
       executor: "constant-vus",
-      vus: 50,
-      duration: "5m",
-      startTime: "1m30s",   // starts after baseline finishes + buffer
+      vus: 15,
+      duration: "1m",
+      startTime: "40s",
       tags: { scenario: "soak" },
     },
     spike: {
       executor: "ramping-vus",
       startVUs: 0,
       stages: [
-        { duration: "30s", target: 300 },  // ramp up hard – reproduces the outage
-        { duration: "1m",  target: 300 },  // hold
-        { duration: "30s", target: 0   },  // ramp down
+        { duration: "15s", target: 50 },
+        { duration: "20s", target: 50 },
+        { duration: "10s", target: 0 },
       ],
-      startTime: "8m",   // starts after soak finishes + buffer
+      startTime: "1m50s",
       tags: { scenario: "spike" },
     },
   },
+  // ── Scenario2: FULL-SCALE VALUES — uncomment to test the outage-scale load ──
+  // scenarios: {
+  //   baseline: {
+  //     executor: "constant-vus",
+  //     vus: 10,
+  //     duration: "1m",
+  //     tags: { scenario: "baseline" },
+  //   },
+  //   soak: {
+  //     executor: "constant-vus",
+  //     vus: 50,
+  //     duration: "5m",
+  //     startTime: "1m30s",   // starts after baseline finishes + buffer
+  //     tags: { scenario: "soak" },
+  //   },
+  //   spike: {
+  //     executor: "ramping-vus",
+  //     startVUs: 0,
+  //     stages: [
+  //       { duration: "30s", target: 300 },  // ramp up hard – reproduces the outage
+  //       { duration: "1m",  target: 300 },  // hold
+  //       { duration: "30s", target: 0   },  // ramp down
+  //     ],
+  //     startTime: "8m",   // starts after soak finishes + buffer
+  //     tags: { scenario: "spike" },
+  //   },
+  // },
 
   thresholds: {
     // Overall error rate must stay below 1 %
@@ -124,7 +152,7 @@ export default function () {
 }
 
 export function handleSummary(data) {
-  // Emit a JUnit-compatible summary for Azure Pipelines
+  // Prints a readable summary to the terminal.
   return {
     // "test-results/k6-load-results.json": JSON.stringify(data, null, 2),
     stdout: textSummary(data),


### PR DESCRIPTION
# Summary of changes
Adds a k6-based load testing script (`tests/load/graphql-load.js`) that simulates concurrent Next.js SSR page loads, reproducing the traffic pattern (#422). No CI/Azure Pipeline integration is included in this PR — this is a manual, on-demand script for now; wiring it into CI can be a follow-up once we're confident in the results.

## What it does

- Simulates real user browsing by requesting HTML pages (`/`, `/about`, `/programs/undergraduate`, `/widget-examples`, `/studentexperience`).
  
- Runs three scenarios in sequence: **baseline** (light sanity check), **soak** (sustained moderate load), and **spike** (a hard ramp-up, simulating a burst of traffic).

- Reports total requests, error rate, p95, and p99 response times.

- Fails (non-zero exit code) if error rate, p95 duration, or spike failure rate exceed defined thresholds — see script comments for exact numbers.

## Prerequisites

Install k6 locally:

https://k6.io/docs/get-started/installation/

brew install k6   # macOS

## Frontend
This PR adds a standalone load testing script that runs against the deployed frontend
from the outside:

- **`tests/load/graphql-load.js`** — new k6 script that simulates
  concurrent users browsing the site 
- **`package.json`** — added `load-test` / `load-test:<env>` scripts as
  shortcuts for running the k6 test with a target `BASE_URL`.

## Backend
N/A
## Checklist

- [X] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [X] My changes are responsive and appear as expected on mobile and desktop views.
- [X] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

# Test Plan

The script ships with two scenario configurations in the `options.scenarios`
block — **only one should be active (uncommented) at a time.**

### Scenario 1 — reduced load (active by default)

Fast to run (~2.5 min total), good for quick local validation.

| Phase | Load |
|---|---|
| baseline | 5 VUs / 30s |
| soak | 15 VUs / 1m |
| spike | up to 50 VUs / ~45s |

**Heads-up before running Scenario 1:**
Only run it against a test/branch environment, never production, and ideally check that no one else is actively relying on that environment at the same time.

To run it, no changes needed — just:

```bash
k6 run --env BASE_URL=https://your-branch.netlify.app tests/load/graphql-load.js , 
```
I conducted all tests against my https://nc-next.netlify.app/ frontend.

### Scenario 2 — full-scale load (commented out)

Matches the actual outage-scale traffic (~13 min total). To test this,
open `tests/load/graphql-load.js` and swap which block is commented:

```js
// Comment out the Scenario 1 block, then uncomment Scenario 2:
scenarios: {
  baseline: { executor: "constant-vus", vus: 10, duration: "1m", ... },
  soak:     { executor: "constant-vus", vus: 50, duration: "5m", ... },
  spike:    { executor: "ramping-vus", stages: [..., target: 300, ...], ... },
},
```

| Phase | Load |
|---|---|
| baseline | 10 VUs / 1m |
| soak | 50 VUs / 5m |
| spike | up to 300 VUs / 2m |

Then run the same command:

```bash
k6 run --env BASE_URL=https://your-branch.netlify.app tests/load/graphql-load.js
```
Please make sure to update the frontend URL, I used https://nc-next.netlify.app/

**Heads-up before running Scenario 2:** this pushes real, sustained
load (up to 300 concurrent virtual users) against whatever `BASE_URL`
you point it at. Only run it against a test/branch environment, never
production, and ideally check that no one else is actively relying on
that environment at the same time.

## Results so far (against nc-next.netlify.app branch deploy)

**Scenario 1 (reduced load):** 0% error rate, p95 ~623ms, p99 ~781ms.
Clean pass, all thresholds met.

**Scenario 2 (full-scale load):** ~41% error rate, p95 ~261ms,
**p99 ~13.9s**. Threshold breaches on `error_rate` and `http_req_failed{scenario:spike}`. Failures were dominated by `dial: i/o timeout` and some `connection reset by peer` errors, concentrated in the soak/spike phases rather than baseline — pointing to a concurrency/capacity limit rather than general slowness. This result was reproducible across two separate full-scale runs.

## Notes for reviewers

- No Azure Pipeline / CI integration yet — deliberately out of scope for this PR, to keep it review-friendly while we validate the approach.
- The `PAGES` array can be can be reviewed/expanded/ modified to include more representative routes.
- Feedback welcome on the threshold values (currently: error rate < 1%, p95 < 3s baseline/soak, p95 < 5s spike, spike failure rate < 2%) — carried over from the original suggestion (#422).