### PR TITLE
Pantheon: Gate /_next/image to prevent optimizer OOM on Cloud Run

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -98,14 +98,26 @@ function getNextConfig(): NextConfig {
     },
   };
 
+  // Cap the optimized-image cache. On Cloud Run the "disk" cache is memory-backed
+  // and maximumDiskCacheSize defaults to unbounded. Ignored under static export.
+  (config.images as Record<string, unknown>).maximumDiskCacheSize = Number(
+    process.env.IMAGE_OPT_MAX_DISK_CACHE_BYTES || 300 * 1024 * 1024
+  );
+
+  // Cap sharp's native decode concurrency to the container's CPU budget. Assigned
+  // unconditionally (the worker-cpu key below layers on) so it always applies;
+  // see server.js for the admission gate that bounds requests reaching /_next/image.
+  config.experimental = { ...config.experimental };
+  (config.experimental as Record<string, unknown>).imgOptConcurrency = Number(
+    process.env.IMAGE_OPT_CONCURRENCY || 2
+  );
+
   // Set number of worker threads used when building pages.
   // Sometimes Drupal struggles to keep up with the load if many requests are made at once,
   // so we can lower the number of threads to reduce the number of requests made in parallel.
   const cpuCount = parseInt(process.env.NEXT_WORKER_CPU_COUNT ?? "");
   if (!isNaN(cpuCount)) {
-    config.experimental = {
-      cpus: cpuCount,
-    };
+    config.experimental.cpus = cpuCount;
   }
 
   if (process.env.NEXT_STATIC_OUTPUT === "true") {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "bun run scripts/prebuild.ts && graphql-codegen && next build",
     "build:webpack": "bun run scripts/prebuild.ts && graphql-codegen && next build --webpack",
-    "start": "next start",
+    "start": "node server.js",
     "static-build": "NEXT_STATIC_OUTPUT=true bun run build:webpack",
     "static-start": "NEXT_STATIC_OUTPUT=true bunx serve@latest out",
     "analyze": "ANALYZE=true next dev",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,94 @@
+// Custom server that gates /_next/image so the in-container image optimizer can't
+// OOM-kill the Cloud Run container under load: cap concurrent optimizations and
+// queue depth, shed overflow with an immediate 503, pass everything else through.
+// It bounds the failure, it does not speed up optimization. Env-configurable:
+// IMAGE_OPT_CONCURRENCY (2), IMAGE_OPT_QUEUE_DEPTH (16), IMAGE_OPT_QUEUE_WAIT_MS (15000).
+const { createServer } = require("http");
+const next = require("next");
+
+const dev = process.env.NODE_ENV !== "production";
+const port = parseInt(process.env.PORT, 10) || 3000;
+const hostname = process.env.HOSTNAME || "0.0.0.0";
+
+const MAX_CONCURRENT_IMAGE_OPS = Number(process.env.IMAGE_OPT_CONCURRENCY || 2);
+const MAX_QUEUE_DEPTH = Number(process.env.IMAGE_OPT_QUEUE_DEPTH || 16);
+const MAX_QUEUE_WAIT_MS = Number(process.env.IMAGE_OPT_QUEUE_WAIT_MS || 15000);
+
+let inFlight = 0;
+const queue = [];
+
+function admit() {
+  inFlight++;
+  return () => {
+    inFlight--;
+    const waiter = queue.shift();
+    if (waiter) waiter();
+  };
+}
+
+function acquireImageSlot() {
+  if (inFlight < MAX_CONCURRENT_IMAGE_OPS) {
+    return Promise.resolve(admit());
+  }
+  if (queue.length >= MAX_QUEUE_DEPTH) {
+    return Promise.reject(new Error("queue_full"));
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      const idx = queue.indexOf(onTurn);
+      if (idx !== -1) queue.splice(idx, 1);
+      reject(new Error("queue_timeout"));
+    }, MAX_QUEUE_WAIT_MS);
+    function onTurn() {
+      clearTimeout(timeout);
+      resolve(admit());
+    }
+    queue.push(onTurn);
+  });
+}
+
+const app = next({ dev, hostname, port });
+const handle = app.getRequestHandler();
+
+app.prepare().then(() => {
+  createServer(async (req, res) => {
+    const isImageOptimize = req.url && req.url.startsWith("/_next/image");
+    if (!isImageOptimize) {
+      handle(req, res);
+      return;
+    }
+
+    let release;
+    try {
+      release = await acquireImageSlot();
+    } catch (err) {
+      const reason = err.message === "queue_full" ? "queue full" : "queue wait exceeded";
+      res.statusCode = 503;
+      res.setHeader("Retry-After", "2");
+      res.setHeader("Content-Type", "text/plain");
+      res.end(`Image optimizer busy (${reason}), retry shortly`);
+      return;
+    }
+
+    let released = false;
+    const releaseOnce = () => {
+      if (released) return;
+      released = true;
+      release();
+    };
+    res.on("finish", releaseOnce);
+    res.on("close", releaseOnce);
+
+    try {
+      await handle(req, res);
+    } catch (err) {
+      releaseOnce();
+      throw err;
+    }
+  }).listen(port, hostname, () => {
+    console.log(`> Ready on http://${hostname}:${port}`);
+    console.log(
+      `> Image optimizer admission: max ${MAX_CONCURRENT_IMAGE_OPS} concurrent, queue depth ${MAX_QUEUE_DEPTH}, max wait ${MAX_QUEUE_WAIT_MS}ms`,
+    );
+  });
+});


### PR DESCRIPTION
Add a custom server.js with a bounded admission queue in front of the Next.js image optimizer, shedding overflow with a 503 so concurrent optimizations can't exhaust container memory. Cap sharp decode concurrency and the optimized-image cache in next.config.ts (fixing the conditional experimental block that dropped the concurrency setting), and point the start script at server.js.

# Summary of changes

Bound the Next.js built-in image optimizer so it cannot exhaust the Node server's memory under concurrent load. When the app is served with `next start`, the optimizer runs in-process: image resizing is effectively serial (sharp is pinned to concurrency 1), and the optimized-image cache is written to the server's filesystem with no size limit by default. Under concurrent traffic, and especially right after a deploy when a freshly started instance re-optimizes many images at once with a cold cache, the optimizer's work queue and cache can grow until the process runs out of memory and restarts, which surfaces as 502s.

This adds an admission gate in front of `/_next/image` that caps concurrent optimizations and sheds overflow, plus two configuration backstops. It bounds the failure by serializing and shedding work. It does not make image optimization faster.

## Frontend

- New `server.js` at the repo root, replacing `next start`. It wraps the Next.js request handler with a bounded semaphore in front of `/_next/image`: at most `IMAGE_OPT_CONCURRENCY` optimizations run at once (default 2), at most `IMAGE_OPT_QUEUE_DEPTH` wait in queue (default 16), and any overflow gets an immediate `503` with a `Retry-After` header before it reaches the image handler. Every non-image request passes through untouched. The concurrency slot is released on both the response `finish` and `close` events and guarded against double-release, so an aborted request cannot leak a slot. All limits are environment-configurable: `IMAGE_OPT_CONCURRENCY`, `IMAGE_OPT_QUEUE_DEPTH`, `IMAGE_OPT_QUEUE_WAIT_MS`.
- `next.config.ts`:
  - Set `experimental.imgOptConcurrency` to cap sharp's native decode concurrency to the server's CPU budget.
  - Set `images.maximumDiskCacheSize` (default 300 MB, `IMAGE_OPT_MAX_DISK_CACHE_BYTES`) to bound the optimized-image cache, which otherwise defaults to unbounded.
  - Fixed a pre-existing bug: `config.experimental` was assigned only inside the `NEXT_WORKER_CPU_COUNT` branch, so the new concurrency setting would have been silently dropped whenever that variable was unset. The assignment is now unconditional and the worker-cpu setting layers on top.
- `package.json`: repointed the `start` script from `next start` to `node server.js`. The `static-start` script (static export served by `serve`) is unchanged, since no Node server runs on that path.

No change to component markup, styling, or client behavior. This is a server and build-configuration change.

## Backend

No backend changes. This does not touch the Drupal site: no new fields, content types, or modules.

## Checklist

- [ ] My changes are accessible (at minimum WCAG 2.0 Level AA)
- [ ] My changes are responsive and appear as expected on mobile and desktop views.
- [ ] My changes have been reviewed to ensure they do not break an existing analytics trigger
- [ ] After merging, I will update the [Content Hub documentation](https://uoguelphca.sharepoint.com/sites/UniversityContentHubInformationGroup) and ensure the Content Hub trainer understands how my changes will affect users.

Note: this is a server-side and build-configuration change with no UI, markup, or analytics impact, so the accessibility, responsive, and analytics items above are not applicable to this PR.

# Test Plan

URLs (fill in once the environments are up):
- Netlify test site: TBD
- Drupal multidev: TBD (created when this PR opens)

Local verification:
1. The project build (`bun run build`) completes unchanged.
2. Start the app with `node server.js` instead of `next start`.
3. Burst test the gate: fire about 30 concurrent requests at `/_next/image?url=...&w=1920&q=75`. Expect a mix of `200` for the admitted requests (concurrency plus queue depth) and an immediate `503` for the overflow, not a long wait. Issue one more request after the burst drains and confirm it returns `200`, which verifies no slot leak.

Load verification on the preview (multidev) environment, which is the test that matters:
4. The failure shows up under concurrent traffic against a freshly deployed instance with a cold cache, so drive load while the environment is building and deploying, not after it has warmed up. Using a k6-based load-testing harness, run sustained image-dense concurrent load against an image-heavy template (news grid, profile listing, spotlight), then trigger a build or redeploy of the environment underneath the load.
5. Compare the patched branch against an unpatched baseline that reliably fails without the gate. Watch server memory, `/_next/image` latency, and 502 count across the deploy. Pass criteria: admitted images return `200`, overflow returns `503` immediately, memory stays bounded, and no out-of-memory restart occurs.
6. Size `IMAGE_OPT_QUEUE_DEPTH` from the measured worst-page image fan-out (about 2x) before recommending the settings for production.